### PR TITLE
cleaning up the token again

### DIFF
--- a/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
@@ -39,7 +39,7 @@ class TwitchWebSocket(): WebSocketListener() {
     override fun onOpen(webSocket: WebSocket, response: Response) {
         super.onOpen(webSocket, response)
         webSocket.send("CAP REQ :twitch.tv/tags twitch.tv/commands");
-        //7rgcke18dgqlo0tiinetfwq6m0ge1c
+        
         //todo: add the User access tokens after oauth:
         webSocket.send("PASS oauth:");
         webSocket.send("NICK theplebdev");


### PR DESCRIPTION
# Related Issue
- n/a


# Proposed changes
- Removing a client token again


# Additional context(optional)
- removing the last client token reference. Now I can link the blog post to my Twitch client websocket
