### PR TITLE
responding to both versions of CLEARMSG

### DIFF
--- a/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
@@ -25,7 +25,7 @@ import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
 enum class MessageType {
-    USER, NOTICE,USERNOTICE,ANNOUNCEMENT,RESUB,SUB,MYSTERYGIFTSUB,GIFTSUB,ERROR,JOIN
+    USER, NOTICE,USERNOTICE,ANNOUNCEMENT,RESUB,SUB,MYSTERYGIFTSUB,GIFTSUB,ERROR,JOIN,CLEARCHAT
 }
 data class TwitchUserData(
     val badgeInfo: String?,
@@ -47,6 +47,7 @@ data class TwitchUserData(
     var userType: String?,
     val messageType: MessageType,
     val deleted:Boolean = false,
+    val banned:Boolean = false
 )
 data class TwitchUserAnnouncement(
     val badgeInfo: String,
@@ -140,6 +141,9 @@ class TwitchWebSocket @Inject constructor(
     private val _messageToDeleteId:MutableStateFlow<String?> = MutableStateFlow(null)
     val messageToDeleteId = _messageToDeleteId.asStateFlow() //this is the text data shown to the user
 
+    private val _bannedUsername:MutableStateFlow<String?> = MutableStateFlow(null)
+    val bannedUsername = _bannedUsername.asStateFlow() //this is the text data shown to the user
+
 
 
 
@@ -213,6 +217,66 @@ class TwitchWebSocket @Inject constructor(
 
      override fun onMessage(webSocket: WebSocket, text: String) {
          Log.d("onMessageSocketStoof","state --> $text")
+
+
+         if(text.contains(" CLEARCHAT ")){
+
+
+             val pattern2 = "#$streamerChannelName$".toRegex()
+             val matcher2 = pattern2.find(text)
+             val found = matcher2?.value
+             if(found !=null){
+                 val userData = TwitchUserData(
+                     badgeInfo = null,
+                     badges = null,
+                     clientNonce = null,
+                     color = "#000000",
+                     displayName = null,
+                     emotes = null,
+                     firstMsg = null,
+                     flags = null,
+                     id = null,
+                     mod = null,
+                     returningChatter = null,
+                     roomId = null,
+                     subscriber = false,
+                     tmiSentTs = null,
+                     turbo = false,
+                     userId = null,
+                     userType = "Connected to chat!",
+                     messageType = MessageType.CLEARCHAT
+                 )
+                 _state.tryEmit(userData)
+             }else{
+                 val pattern3 = ":(\\w+)\\s*$".toRegex()
+
+// Use a Matcher to find the pattern in the input string
+                 val matcher3 = pattern3.find(text)
+                 val username = matcher3?.groupValues?.last()
+                 val userData = TwitchUserData(
+                     badgeInfo = null,
+                     badges = null,
+                     clientNonce = null,
+                     color = "#000000",
+                     displayName = username,
+                     emotes = null,
+                     firstMsg = null,
+                     flags = null,
+                     id = null,
+                     mod = null,
+                     returningChatter = null,
+                     roomId = null,
+                     subscriber = false,
+                     tmiSentTs = null,
+                     turbo = false,
+                     userId = null,
+                     userType = "Connected to chat!",
+                     messageType = MessageType.CLEARCHAT
+                 )
+                 _state.tryEmit(userData)
+             }
+
+         }
 
          if(text.contains(" USERSTATE ")){
              Log.d("loggedInDataOnMessage","USERSTATE --> $text") //TODO: I THINK THIS IS WHERE THE BUG IS

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -1421,6 +1421,9 @@ fun ChatCard(
                     if(twitchUser.deleted){
                         Text("Moderator deleted Comment", fontSize = 20.sp,modifier = Modifier.padding(start = 5.dp))
                     }
+                    if(twitchUser.banned){
+                        Text("Banned by moderator", fontSize = 20.sp,modifier = Modifier.padding(start = 5.dp))
+                    }
                     Row(
                         verticalAlignment = Alignment.CenterVertically
                     ){

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -124,6 +124,7 @@ class StreamViewModel @Inject constructor(
     }
 
 
+
     fun changeTimeoutDuration(duration:Int){
         _uiState.value = _uiState.value.copy(
             timeoutDuration = duration
@@ -153,6 +154,16 @@ class StreamViewModel @Inject constructor(
         listChats[foundIndex] = found.copy(
             deleted = true
         )
+    }
+    private fun banUserFilter(username:String){
+
+        listChats.filter { it.displayName == username }.forEach{
+            val index = listChats.indexOf(it)
+            listChats[index] = it.copy(
+                banned = true
+            )
+
+        }
     }
 
     fun deleteChatMessage(messageId:String) = viewModelScope.launch{
@@ -292,6 +303,12 @@ class StreamViewModel @Inject constructor(
 
                     clickedUsernameChats.add(twitchUserMessage.userType!!)
 
+                }
+                if(twitchUserMessage.messageType == MessageType.CLEARCHAT && twitchUserMessage.displayName == null){
+                    listChats.clear()
+                }
+                if(twitchUserMessage.messageType == MessageType.CLEARCHAT && twitchUserMessage.displayName != null){
+                    banUserFilter(twitchUserMessage.displayName)
                 }
 
 


### PR DESCRIPTION
# Related Issue
- #234 


# Proposed changes
- the app now responds to both types of CLEARMSG messages. One for clearing the entire chat logs and one for banning the user


# Additional context(optional)
- Now we can work on implementing what will happen on a failed ban attemp
