### PR TITLE
 ban duration parsing

### DIFF
--- a/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
@@ -47,7 +47,8 @@ data class TwitchUserData(
     var userType: String?,
     val messageType: MessageType,
     val deleted:Boolean = false,
-    val banned:Boolean = false
+    val banned:Boolean = false,
+    val bannedDuration:Int? = null
 )
 data class TwitchUserAnnouncement(
     val badgeInfo: String,
@@ -221,6 +222,12 @@ class TwitchWebSocket @Inject constructor(
 
          if(text.contains(" CLEARCHAT ")){
 
+             val banDurationPattern = "ban-duration=(\\d+)".toRegex()
+
+             val banDurationMatch = banDurationPattern.find(text)
+             val foundDuration = banDurationMatch?.groupValues?.last()?.toInt()
+             Log.d("WEBSOCKETBANDURATION","foundDuration --> $foundDuration")
+
 
              val pattern2 = "#$streamerChannelName$".toRegex()
              val matcher2 = pattern2.find(text)
@@ -244,7 +251,8 @@ class TwitchWebSocket @Inject constructor(
                      turbo = false,
                      userId = null,
                      userType = "Connected to chat!",
-                     messageType = MessageType.CLEARCHAT
+                     messageType = MessageType.CLEARCHAT,
+                     bannedDuration = foundDuration
                  )
                  _state.tryEmit(userData)
              }else{
@@ -271,7 +279,8 @@ class TwitchWebSocket @Inject constructor(
                      turbo = false,
                      userId = null,
                      userType = "Connected to chat!",
-                     messageType = MessageType.CLEARCHAT
+                     messageType = MessageType.CLEARCHAT,
+                     bannedDuration = foundDuration
                  )
                  _state.tryEmit(userData)
              }

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -1481,8 +1481,10 @@ fun ChatCard(
                     if(twitchUser.deleted){
                         Text("Moderator deleted Comment", fontSize = 20.sp,modifier = Modifier.padding(start = 5.dp))
                     }
+
                     if(twitchUser.banned){
-                        Text("Banned by moderator", fontSize = 20.sp,modifier = Modifier.padding(start = 5.dp))
+                        val duration = if (twitchUser.bannedDuration != null) "Banned for ${twitchUser.bannedDuration} seconds" else "Banned permanently"
+                        Text(duration, fontSize = 20.sp,modifier = Modifier.padding(start = 5.dp))
                     }
                     Row(
                         verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -159,12 +159,13 @@ class StreamViewModel @Inject constructor(
             deleted = true
         )
     }
-    private fun banUserFilter(username:String){
+    private fun banUserFilter(username:String,banDuration:Int?){
 
         listChats.filter { it.displayName == username }.forEach{
             val index = listChats.indexOf(it)
             listChats[index] = it.copy(
-                banned = true
+                banned = true,
+                bannedDuration = banDuration
             )
 
         }
@@ -312,7 +313,11 @@ class StreamViewModel @Inject constructor(
                     listChats.clear()
                 }
                 if(twitchUserMessage.messageType == MessageType.CLEARCHAT && twitchUserMessage.displayName != null){
-                    banUserFilter(twitchUserMessage.displayName)
+                    Log.d("collectingdatathingy","foundDuration --> ${twitchUserMessage.bannedDuration}")
+                    banUserFilter(
+                       username= twitchUserMessage.displayName,
+                        banDuration = twitchUserMessage.bannedDuration
+                    )
                 }
 
 


### PR DESCRIPTION
# Related Issue
- #254 


# Proposed changes
- using regex to pull out the `ban-duration=32432` information


# Additional context(optional)
- now we can work on the failed timeoutUI. Also need the undo button for a successful timeout
