### PR TITLE
removing the bonker settings from chatUI

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -527,7 +527,7 @@ fun ChatSettingsDataUI(
 
 
     var tabIndex by remember { mutableIntStateOf(0) }
-    val titles = listOf("Settings", "Bonker")
+    val titles = listOf("Chat room Settings")
     Column {
         TabRow(selectedTabIndex = tabIndex) {
             titles.forEachIndexed { index, title ->


### PR DESCRIPTION
# Related Issue
- #278 


# Proposed changes
- removed the Bonker settings from the UI. Will add it back when version two comes out.


# Additional context(optional)
- Now I can work on the no internet settings notificaction
