### PR TITLE
adding the basic logout error handling

### DIFF
--- a/app/src/main/java/com/example/clicker/network/repository/TwitchRepoImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchRepoImpl.kt
@@ -52,7 +52,7 @@ class TwitchRepoImpl @Inject constructor(
     ): Flow<Response<List<StreamInfo>>> = flow{
         emit(Response.Loading)
         Log.d("GETTINGLIVESTREAMS","getFollowedLiveStreams() IS RUN")
-        
+
         val response = twitchClient.getFollowedStreams(
             authorization = "Bearer $authorizationToken",
             clientId = clientId,
@@ -81,6 +81,7 @@ class TwitchRepoImpl @Inject constructor(
 
     override fun logout(clientId:String,token:String): Flow<Response<String>> = flow{
         emit(Response.Loading)
+        
         val response = twitchClient.logout(clientId = clientId, token = token)
         if (response.isSuccessful){
             Log.d("logoutResponse", "SUCCESS ->${response.message()}")
@@ -91,6 +92,16 @@ class TwitchRepoImpl @Inject constructor(
             emit(Response.Failure(Exception("Error!, code: {${response.code()}}")))
 
         }
+    }.catch { cause ->
+        Log.d("GETTINGLIVESTREAMS","CAUSE IS CAUSE")
+        //Log.d("GETTINGLIVESTREAMS","RUNNING THE METHOD USER--> $user ")
+        if(cause is UnknownHostException){
+            emit(Response.Failure(Exception("Network Error! Please check your connection and try again")))
+        }else{
+            emit(Response.Failure(Exception("Logout Error! Please try again")))
+        }
+
+
     }
 
     override suspend fun getChatSettings(

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
@@ -179,6 +179,8 @@ fun HomeView(
                 loginStep1 = homeViewModel.loginState.value.loginStep1,
                 loginStep2 = homeViewModel.loginState.value.loginStep2,
                 loginStep3 = homeViewModel.loginState.value.loginStep3,
+                logoutError = homeViewModel.loginState.value.logoutError,
+                logout = {homeViewModel.beginLogout()}
             )
         }
 
@@ -232,7 +234,9 @@ fun LoginModal(
     loginStatusText:String,
     loginStep1:Response<Boolean>?,
     loginStep2:Response<Boolean>?,
-    loginStep3:Response<Boolean>?
+    loginStep3:Response<Boolean>?,
+    logoutError:Boolean,
+    logout:()-> Unit
 
 ) {
             Spacer(
@@ -249,7 +253,9 @@ fun LoginModal(
             loginStatusText,
             loginStep1,
             loginStep2,
-            loginStep3
+            loginStep3,
+            logoutError,
+            logout = {logout()}
 
 
         )
@@ -265,7 +271,9 @@ fun LoginCard(
     statusText:String,
     loginStep1:Response<Boolean>?,
     loginStep2:Response<Boolean>?,
-    loginStep3:Response<Boolean>?
+    loginStep3:Response<Boolean>?,
+    logoutError:Boolean,
+    logout:()-> Unit
 ){
     val configuration = LocalConfiguration.current
 
@@ -310,9 +318,16 @@ fun LoginCard(
                 .padding(bottom = 10.dp),
                 textAlign = TextAlign.Center
             )
-            Button(onClick = { loginWithTwitch() }) {
-                Text("Login with Twitch")
+            if(logoutError){
+                Button(onClick = { logout() }) {
+                    Text("Attempt logout again")
+                }
+            }else{
+                Button(onClick = { loginWithTwitch() }) {
+                    Text("Login with Twitch")
+                }
             }
+
         }
 
 

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -51,6 +51,8 @@ data class LoginStatus(
     val loginStep1: Response<Boolean>? = Response.Loading,
     val loginStep2: Response<Boolean>? = null,
     val loginStep3: Response<Boolean>? = null,
+    val logoutError:Boolean = false
+
 
 )
 
@@ -279,9 +281,18 @@ class HomeViewModel @Inject constructor(
                         loginStep1 = Response.Success(true),
                         loginStep2 = Response.Success(true),
                         loginStep3 = null,
+                        logoutError = false
                     )
                 }
-                is Response.Failure ->{}
+                is Response.Failure ->{
+                    _loginUIState.value = _loginUIState.value.copy(
+                        loginStatusText = response.e.message ?: "Logout Error! Please try again",
+                        loginStep1 = Response.Success(true),
+                        loginStep2 = Response.Failure(Exception("failed to Logout")),
+                        loginStep3 = null,
+                        logoutError = true
+                    )
+                }
                 else -> {}
             }
         }


### PR DESCRIPTION
# Related Issue
- #283 


# Proposed changes
- Added the basic exception handling for the logout method. 
- Might have caused another UI bug, however, it seem to resolved itself. So lets just hope that the user does not logout and log back in too much. Or just assume the sheer confusion keeps them from clicking anything. 


# Additional context(optional)
- Now we can move on to the get chat settings error handling 
