### PR TITLE
adding the basic exception handling for updateChatSettings

### DIFF
--- a/app/src/main/java/com/example/clicker/network/repository/TwitchRepoImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchRepoImpl.kt
@@ -142,6 +142,7 @@ class TwitchRepoImpl @Inject constructor(
         body: UpdateChatSettings
     ): Flow<Response<Boolean>>  = flow{
         emit(Response.Loading)
+        throw Exception("IT DO BE LIKE THAT SOMETIMES")
         val response =twitchClient.updateChatSettings(
             authorizationToken = "Bearer $oAuthToken",
             clientId = clientId,
@@ -155,6 +156,16 @@ class TwitchRepoImpl @Inject constructor(
         }else{
             emit(Response.Failure(Exception(response.message())))
         }
+    }.catch { cause ->
+        Log.d("GETTINGLIVESTREAMS","CAUSE IS CAUSE")
+        //Log.d("GETTINGLIVESTREAMS","RUNNING THE METHOD USER--> $user ")
+        if(cause is UnknownHostException){
+            emit(Response.Failure(Exception("response.message()")))
+        }else{
+            emit(Response.Failure(Exception("response.message()")))
+        }
+
+
     }
 
     override suspend fun deleteChatMessage(

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -814,7 +814,7 @@ fun MessageAlertText(message: String){
                 tint = Color.Red
                 )
             Text(
-                message,
+                "Request failed",
                 textAlign = TextAlign.Center,
                 fontSize = 30.sp,
                 modifier = Modifier.align(Alignment.Center)


### PR DESCRIPTION
# Related Issue
- #283 


# Proposed changes
- adding the basic exception handling for the updateChatSettings


# Additional context(optional)
- Now we can move on to removing the failed request message
