### PR TITLE
adding delete message exception handling

### DIFF
--- a/app/src/main/java/com/example/clicker/network/repository/TwitchRepoImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchRepoImpl.kt
@@ -176,6 +176,7 @@ class TwitchRepoImpl @Inject constructor(
         messageId: String
     ): Flow<Response<Boolean>> = flow {
         emit(Response.Loading)
+        
         val response = twitchClient.deleteChatMessage(
             authorizationToken = "Bearer ${oAuthToken}",
             clientId = clientId,
@@ -186,10 +187,21 @@ class TwitchRepoImpl @Inject constructor(
         if(response.isSuccessful){
             emit(Response.Success(true))
         }else{
-            Log.d("deleteChatMessageException",response.message())
-            Log.d("deleteChatMessageException",response.code().toString())
-            emit(Response.Failure(Exception("MESSAGE NOT DELETED")))
+
+            emit(Response.Failure(Exception("Unable to delete message")))
         }
+    }.catch { cause ->
+
+        //Log.d("GETTINGLIVESTREAMS","RUNNING THE METHOD USER--> $user ")
+        if(cause is UnknownHostException){
+
+            emit(Response.Failure(Exception("Failed. Network connection error")))
+        }else{
+
+            emit(Response.Failure(Exception("Unable to delete message")))
+        }
+
+
     }
 
     override suspend fun banUser(

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -188,11 +188,7 @@ class StreamViewModel @Inject constructor(
             moderatorId = _uiState.value.userId,
             messageId = messageId
         ).collect{response ->
-            Log.d("deleteChatMessageStoof",_uiState.value.oAuthToken)
-            Log.d("deleteChatMessageStoof",_uiState.value.clientId)
-            Log.d("deleteChatMessageStoof",_uiState.value.broadcasterId)
-            Log.d("deleteChatMessageStoof",_uiState.value.userId)
-            Log.d("deleteChatMessageStoof",messageId)
+
             when(response){
                 is Response.Loading ->{
                     Log.d("deleteChatMessage","LOADING")
@@ -202,6 +198,11 @@ class StreamViewModel @Inject constructor(
                 }
                 is Response.Failure ->{
                     Log.d("deleteChatMessage","FAILURE")
+                    _uiState.value = _uiState.value.copy(
+                        showStickyHeader = true,
+                        undoBanResponse = false,
+                        banResponseMessage = "${response.e.message}"
+                    )
                 }
             }
 


### PR DESCRIPTION
# Related Issue
- #292 


# Proposed changes
- adding the exception handling for the deleteChatMessage() method and working in the sticky header exception message


# Additional context(optional)
- Now can work on the unbanUser exception
