### PR TITLE
adding the nonlatin parsing to clearChat

### DIFF
--- a/app/src/main/java/com/example/clicker/network/websockets/ParsingEngine.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/ParsingEngine.kt
@@ -102,7 +102,7 @@ class ParsingEngine {
         //THIS IS TO BAN USER @room-id=520593641;target-user-id=949335660;tmi-sent-ts=1696019132494 :tmi.twitch.tv CLEARCHAT #theplebdev :meanermeeny
         //todo: I want this to modify the messages like it currently is but also sent a little message stating what user was banned
         //todo: I need to parse out the userId. target-user-id=949335660
-        val banUserPattern = "[a-zA-Z0-9_]+$".toRegex()
+        val banUserPattern = "([^:]+)$".toRegex()
         val bannedUserIdPattern = "target-user-id=(\\d+)".toRegex()
 
         val bannedUserUsername = banUserPattern.find(text)

--- a/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
+++ b/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
@@ -53,4 +53,23 @@ class ParsingEngineTest {
 
 
     }
+    //TODO: TEST USERNAME PARSING WITH NON LATIN BASED ALPHABETS
+    // 板橋小結巴 THIS IS A MANDARIN BASED USER NAME
+
+    @Test
+    fun ban_user_parsing_with_non_latin_alphabet(){
+        val EXPECTED_BANNEDUSERID = "949335660"
+        val EXPECTED_USERNAME = "板橋小結巴"
+
+        val BAN_USER_TEXT = "@room-id=520593641;target-user-id=949335660;tmi-sent-ts=1696019132494 :tmi.twitch.tv CLEARCHAT #theplebdev :板橋小結巴"
+        val STREAMER_NAME = "theplebdev"
+
+        /* When */
+        val result = underTest.clearChatTesting(text = BAN_USER_TEXT, streamerName = STREAMER_NAME)
+
+
+        /* Then */
+        Assert.assertEquals(EXPECTED_USERNAME, result.displayName )
+
+    }
 }


### PR DESCRIPTION
# Related Issue
- #307


# Proposed changes
- needed to add some extra things to accommodate the non-Latin alphabets 


# Additional context(optional)
- Now we can move on to the next parsing
