### PR TITLE
adding the USERSTATE parsing and testing

### DIFF
--- a/app/src/main/java/com/example/clicker/network/websockets/ParsingEngine.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/ParsingEngine.kt
@@ -179,11 +179,12 @@ class ParsingEngine {
         val modStatusMatch = modStatusPattern.find(text)
         val subStatusMatch = subStatusPattern.find(text)
 
+
         val loggedData =LoggedInUserData(
             color =colorMatch?.groupValues?.get(1),
             displayName = displayNameMatch?.groupValues?.get(1)!!,
-            mod = stringToBoolean(modStatusMatch?.groupValues?.get(1)!!),
-            sub = stringToBoolean(subStatusMatch?.groupValues?.get(1)!!)
+            mod = modStatusMatch?.groupValues?.get(1)!! == "1",
+            sub = subStatusMatch?.groupValues?.get(1)!! == "1"
 
         )
 

--- a/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
@@ -224,9 +224,11 @@ class TwitchWebSocket @Inject constructor(
          }
 
          if(text.contains(" USERSTATE ")){
-             Log.d("loggedInDataOnMessage","USERSTATE --> $text") //TODO: I THINK THIS IS WHERE THE BUG IS
+             Log.d("USERSTATESTUFF","USERSTATE --> $text") //TODO: I THINK THIS IS WHERE THE BUG IS
+             val parsedTwitchInUserData = ParsingEngine().userStateParsing(text)
+
              _loggedInUserUiState.tryEmit(
-                 getLoggedInUserInfo(text)
+                 parsedTwitchInUserData
              )
 
          }
@@ -522,38 +524,8 @@ fun filterText(chatText:String):String{
 
     return matchResult?.groupValues?.getOrNull(2)?.trim() ?: ""
 }
-fun getLoggedInUserInfo(text:String): LoggedInUserData {
-    val colorPattern = "color=([^;]+)".toRegex()
-    val displayNamePattern = "display-name=([^;]+)".toRegex()
-    val modStatusPattern = "mod=([^;]+)".toRegex()
-    val subStatusPattern = "subscriber=([^;]+)".toRegex()
 
 
-    val colorMatch = colorPattern.find(text)
-    val displayNameMatch = displayNamePattern.find(text)
-    val modStatusMatch = modStatusPattern.find(text)
-    val subStatusMatch = subStatusPattern.find(text)
-
-
-
-    val loggedData =LoggedInUserData(
-        color =colorMatch?.groupValues?.get(1),
-        displayName = displayNameMatch?.groupValues?.get(1)!!,
-        mod = stringToBoolean(modStatusMatch?.groupValues?.get(1)!!),
-        sub = stringToBoolean(subStatusMatch?.groupValues?.get(1)!!)
-
-    )
-    Log.d("loggedData","loggedDataObject --> $loggedData")
-
-
-    return loggedData
-}
-fun stringToBoolean( subOrModText:String):Boolean{
-    val convertedString = subOrModText.toInt()
-
-    return convertedString ==1
-
-}
 
 fun getValueFromInput(input: String, key: String): Boolean? {
     val pattern = "$key=([^;:\\s]+)".toRegex()

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -123,7 +123,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.window.Dialog
 import coil.compose.AsyncImage
 import com.example.clicker.network.models.ChatSettingsData
-import com.example.clicker.network.websockets.LoggedInUserData
+
 import com.example.clicker.network.websockets.MessageType
 import com.example.clicker.presentation.home.HomeViewModel
 import com.example.clicker.util.Response

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -15,10 +15,11 @@ import com.example.clicker.network.BanUserData
 import com.example.clicker.network.domain.TwitchRepo
 import com.example.clicker.network.models.ChatSettingsData
 import com.example.clicker.network.models.UpdateChatSettings
-import com.example.clicker.network.websockets.LoggedInUserData
+
 import com.example.clicker.network.websockets.MessageType
 import com.example.clicker.network.websockets.TwitchUserData
 import com.example.clicker.network.websockets.TwitchWebSocket
+import com.example.clicker.network.websockets.models.LoggedInUserData
 import com.example.clicker.util.Response
 import com.example.clicker.util.objectMothers.TwitchUserDataObjectMother
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
+++ b/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
@@ -78,12 +78,23 @@ class ParsingEngineTest {
     @Test
     fun user_state_parsing(){
         /* Given */
-        val EXPECTED_LOGGEDIN_USER_STATE = LoggedInUserDataObjectMother
-            .addColor("#000000")
-            .addDisplayName("bobber-micky54$")
-            .addMod(true)
-            .addSub(true)
-            .build()
+        val EXPECTED_COLOR = "#000000"
+        val EXPECTED_DISPLAYNAME="bobber-micky54$"
+        val EXPECTED_MOD = 0
+        val EXPECTED_SUB = 0
+        val givenString = "@badge-info=;badges=staff/1;color=$EXPECTED_COLOR;display-name=$EXPECTED_DISPLAYNAME;emote-sets=0,33,50,237,793,2126,3517,4578,5569,9400,10337,12239;mod=$EXPECTED_MOD;subscriber=$EXPECTED_SUB;turbo=1;user-type=staff :tmi.twitch.tv USERSTATE #dallas"
+
+
+        /* When */
+        val result = underTest.userStateParsing(givenString)
+
+        /* Then */
+        Assert.assertEquals(EXPECTED_COLOR, result.color )
+        Assert.assertEquals(EXPECTED_DISPLAYNAME, result.displayName )
+        Assert.assertEquals(false, result.mod )
+        Assert.assertEquals(false, result.sub )
+
+
 
     }
 }


### PR DESCRIPTION
# Related Issue
- #320 


# Proposed changes
- adding the USERSTATE parsing and testing
- also, added the LoggedInUserDataObjectMother


# Additional context(optional)
- Now we can move on to the CLEARMSG parsing
