### PR TITLE
adding and testing the clear message parsing

### DIFF
--- a/app/src/main/java/com/example/clicker/network/websockets/ParsingEngine.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/ParsingEngine.kt
@@ -193,5 +193,17 @@ class ParsingEngine {
 
 
     }
+    /**
+     * Parses the websocket data sent from twitch. Will run when a CLEARMSG command is sent
+     * @property text the string to be parsed
+     * @return a nullable string containing the id of the message to be deleted
+     */
+    fun clearMsgParsing(text:String):String?{
+        val pattern = "target-msg-id=([^;]+)".toRegex()
+
+        val messageId = pattern.find(text)?.groupValues?.get(1)
+        return messageId
+
+    }
 
 }

--- a/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
@@ -224,7 +224,7 @@ class TwitchWebSocket @Inject constructor(
          }
 
          if(text.contains(" USERSTATE ")){
-             Log.d("USERSTATESTUFF","USERSTATE --> $text") //TODO: I THINK THIS IS WHERE THE BUG IS
+
              val parsedTwitchInUserData = ParsingEngine().userStateParsing(text)
 
              _loggedInUserUiState.tryEmit(
@@ -234,13 +234,7 @@ class TwitchWebSocket @Inject constructor(
          }
          if(text.contains(" CLEARMSG ")){
 
-
-// Define the regex pattern to match "target-msg-id"
-             val pattern = "target-msg-id=([^;]+)".toRegex()
-
-// Use a Matcher to find the pattern in the input string
-             val messageId = pattern.find(text)?.groupValues?.get(1)
-            // Log.d("onMessageSocketStoofPasred","MSGID --> $messageId")
+             val messageId = ParsingEngine().clearMsgParsing(text)
              _messageToDeleteId.tryEmit(messageId)
 
          }

--- a/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
+++ b/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
@@ -97,4 +97,18 @@ class ParsingEngineTest {
 
 
     }
+
+    @Test
+    fun clear_message_parsing(){
+        /* Given */
+        val EXPECTED_MSG_ID ="94e6c7ff-bf98-4faa-af5d-7ad633a158a9"
+        val parsingString ="@login=foo;room-id=;target-msg-id=$EXPECTED_MSG_ID;tmi-sent-ts=1642720582342 :tmi.twitch.tv CLEARMSG #bar :what a great day"
+
+        /* When */
+        val result = underTest.clearMsgParsing(parsingString)
+
+
+        /* Then */
+        Assert.assertEquals(EXPECTED_MSG_ID, result )
+    }
 }


### PR DESCRIPTION
# Related Issue
- #323 


# Proposed changes
- moved the CLEARMSG parsing over to the parsing engine and tested it


# Additional context(optional)
- now we can move on to the JOIN parsing
