### PR TITLE
adding the USERNOTICE parsing to the engine and testing

### DIFF
--- a/app/src/main/java/com/example/clicker/network/websockets/models/DataClases.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/models/DataClases.kt
@@ -1,10 +1,12 @@
 package com.example.clicker.network.websockets.models
 
+import com.example.clicker.network.websockets.MessageType
+
 
 /**
  * Represents the state of the logged in User
  *
- * This class has no useful logic; it's just a documentation example.
+ * This class is used primarily in the view for its mod status
  *
  * @property color   representing the color of the username
  * @property displayName  representing the name of the user which is displayed on screen and to other users
@@ -17,4 +19,62 @@ data class LoggedInUserData(
     val displayName: String,
     val sub:Boolean,
     val mod:Boolean
+)
+
+/**
+ * Represents the state of the chatting user
+ *
+ * This class is used constantly to represent each individual chat message
+ *
+ * @property badgeInfo   representing the color of the username
+ * @property badges  representing the name of the user which is displayed on screen and to other users
+ * @property clientNonce representing if the user is a subscriber or not
+ * @property color  representing if the user is a moderator or not
+ * @property displayName   representing the color of the username
+ * @property emotes  representing the name of the user which is displayed on screen and to other users
+ * @property firstMsg representing if the user is a subscriber or not
+ * @property flags  representing if the user is a moderator or not
+ *
+ * @property id   representing the color of the username
+ * @property mod  representing the name of the user which is displayed on screen and to other users
+ * @property returningChatter representing if the user is a subscriber or not
+ * @property roomId  representing if the user is a moderator or not
+ * @property subscriber   representing the color of the username
+ * @property tmiSentTs  representing the name of the user which is displayed on screen and to other users
+ * @property turbo representing if the user is a subscriber or not
+ * @property userId  representing if the user is a moderator or not
+ * @property roomId  representing if the user is a moderator or not
+ *
+ * @property userType   representing the color of the username
+ * @property messageType  representing the name of the user which is displayed on screen and to other users
+ * @property deleted representing if the user is a subscriber or not
+ * @property banned  representing if the user is a moderator or not
+ * @property bannedDuration  representing if the user is a moderator or not
+ *
+ * @property systemMessage representing a message sent by the Twitch irc server
+ * @constructor Creates the state representing a chatting user.
+ */
+data class TwitchUserData(
+    val badgeInfo: String?,
+    val badges: String?,
+    val clientNonce: String?,
+    val color: String?,
+    val displayName: String?,
+    val emotes: String?,
+    val firstMsg: String?,
+    val flags: String?,
+    val id: String?,
+    val mod: String?,
+    val returningChatter: String?,
+    val roomId: String?,
+    val subscriber: Boolean,
+    val tmiSentTs: Long?,
+    val turbo: Boolean,
+    val userId: String?,
+    var userType: String?,
+    val messageType: MessageType,
+    val deleted:Boolean = false,
+    val banned:Boolean = false,
+    val bannedDuration:Int? = null,
+    val systemMessage:String? = null
 )

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -18,7 +18,6 @@ import com.example.clicker.network.models.StreamData
 import com.example.clicker.network.models.ValidatedUser
 import com.example.clicker.network.models.toStreamInfo
 import com.example.clicker.network.repository.TwitchRepoImpl
-import com.example.clicker.network.websockets.TwitchUserData
 import com.example.clicker.network.websockets.TwitchWebSocket
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.clicker.network.websockets.TwitchUserData
 import kotlinx.coroutines.launch
 import android.graphics.Color.parseColor
 import androidx.compose.animation.Animatable
@@ -156,6 +155,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import com.example.clicker.network.BanUser
 import com.example.clicker.network.BanUserData
+import com.example.clicker.network.websockets.models.TwitchUserData
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlin.math.abs
@@ -1003,29 +1003,34 @@ fun TextChat(
                             MessageType.ANNOUNCEMENT ->{
                                 AnnouncementMessage(
                                     displayName = twitchUser.displayName,
-                                    message = twitchUser.userType
+                                    message = twitchUser.userType,
+                                    systemMessage = twitchUser.systemMessage
                                 )
                             }
                             MessageType.RESUB ->{
                                 ResubMessage(
-                                    message = twitchUser.userType
+                                    message = twitchUser.userType,
+                                    systemMessage = twitchUser.systemMessage
                                 )
 
                             }
                             MessageType.SUB ->{
                                 SubMessage(
-                                    message = twitchUser.userType
+                                    message = twitchUser.userType,
+                                    systemMessage = twitchUser.systemMessage
                                 )
                             }
                             //MYSTERYGIFTSUB,GIFTSUB
                             MessageType.GIFTSUB ->{
                                 GiftSubMessage(
-                                    message = twitchUser.userType
+                                    message = twitchUser.userType,
+                                    systemMessage = twitchUser.systemMessage
                                 )
                             }
                             MessageType.MYSTERYGIFTSUB ->{
                                 MysteryGiftSubMessage(
-                                    message = twitchUser.userType
+                                    message = twitchUser.userType,
+                                    systemMessage = twitchUser.systemMessage
                                 )
 
                             }
@@ -1146,8 +1151,11 @@ fun ErrorMessage(
 }
 @Composable
 fun MysteryGiftSubMessage(
-    message:String?
+    message:String?,
+    systemMessage: String?
 ){
+    val personalMessage = message ?: ""
+    val twitchIRCMessage = systemMessage ?:""
     Row(modifier = Modifier
         .fillMaxWidth()
         .background(Color.Black.copy(alpha = 0.6f))){
@@ -1176,7 +1184,8 @@ fun MysteryGiftSubMessage(
             Text(buildAnnotatedString {
 //
                 withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
-                    append(" ${message}")
+                    append(" ${twitchIRCMessage}")
+                    append(" ${personalMessage}")
                 }
             }
             )
@@ -1187,8 +1196,11 @@ fun MysteryGiftSubMessage(
 
 @Composable
 fun GiftSubMessage(
-    message:String?
+    message:String?,
+    systemMessage: String?
 ){
+    val personalMessage = message ?:""
+    val twitchIRCMessage = systemMessage ?:""
     Row(modifier = Modifier
         .fillMaxWidth()
         .background(Color.Black.copy(alpha = 0.6f))){
@@ -1217,7 +1229,8 @@ fun GiftSubMessage(
             Text(buildAnnotatedString {
 //
                 withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
-                    append(" ${message}")
+                    append(" ${twitchIRCMessage}")
+                    append(" ${personalMessage}")
                 }
             }
             )
@@ -1227,8 +1240,11 @@ fun GiftSubMessage(
 }
 @Composable
 fun SubMessage(
-    message:String?
+    message:String?,
+    systemMessage: String?
 ){
+    val TwitchIRCMessage = systemMessage ?:""
+    val personalMessage = message?:""
     Row(modifier = Modifier
         .fillMaxWidth()
         .background(Color.Black.copy(alpha = 0.6f))){
@@ -1256,7 +1272,8 @@ fun SubMessage(
 
             Text(buildAnnotatedString {
                 withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
-                    append(" ${message}")
+                    append(" ${TwitchIRCMessage}")
+                    append(" ${personalMessage}")
                 }
             }
             )
@@ -1266,8 +1283,10 @@ fun SubMessage(
 
 @Composable
 fun ResubMessage(
-    message:String?
+    message:String?,
+    systemMessage:String?
 ){
+    val personalMessage = message ?:""
     Row(modifier = Modifier
         .fillMaxWidth()
         .background(Color.Black.copy(alpha = 0.6f))){
@@ -1296,7 +1315,8 @@ fun ResubMessage(
             Text(buildAnnotatedString {
 
                 withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
-                    append(" ${message}")
+                    append(" $systemMessage")
+                    append(" $personalMessage")
                 }
             }
             )
@@ -1327,8 +1347,11 @@ fun NoticeMessage(
 @Composable
 fun AnnouncementMessage(
     displayName:String?,
-    message:String?
+    message:String?,
+    systemMessage: String?
 ){
+    val personalMessage = message ?: ""
+    val twitchIRCMessage = systemMessage ?: ""
     Row(modifier = Modifier
         .fillMaxWidth()
         .background(Color.Black.copy(alpha = 0.6f))){
@@ -1359,7 +1382,8 @@ fun AnnouncementMessage(
                     append("${displayName} :")
                 }
                 withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
-                    append(" ${message}")
+                    append(" ${twitchIRCMessage}")
+                    append(" ${personalMessage}")
                 }
             }
             )

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -17,9 +17,9 @@ import com.example.clicker.network.models.ChatSettingsData
 import com.example.clicker.network.models.UpdateChatSettings
 
 import com.example.clicker.network.websockets.MessageType
-import com.example.clicker.network.websockets.TwitchUserData
 import com.example.clicker.network.websockets.TwitchWebSocket
 import com.example.clicker.network.websockets.models.LoggedInUserData
+import com.example.clicker.network.websockets.models.TwitchUserData
 import com.example.clicker.util.Response
 import com.example.clicker.util.objectMothers.TwitchUserDataObjectMother
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/example/clicker/util/objectMothers/TwitchUserDataObjectMother.kt
+++ b/app/src/main/java/com/example/clicker/util/objectMothers/TwitchUserDataObjectMother.kt
@@ -1,14 +1,14 @@
 package com.example.clicker.util.objectMothers
 
 import com.example.clicker.network.websockets.MessageType
-import com.example.clicker.network.websockets.TwitchUserData
+import com.example.clicker.network.websockets.models.TwitchUserData
 
 class TwitchUserDataObjectMother private constructor() {
 
 
     companion object{
 
-        private var twitchUserData: TwitchUserData =TwitchUserData(
+        private var twitchUserData: TwitchUserData = TwitchUserData(
             badgeInfo = null,
             badges = null,
             clientNonce = null,
@@ -27,7 +27,8 @@ class TwitchUserDataObjectMother private constructor() {
             userId = null,
             userType = null,
             messageType = MessageType.CLEARCHAT,
-            bannedDuration = null
+            bannedDuration = null,
+            systemMessage = null
         )
 
         fun build():TwitchUserData{
@@ -113,7 +114,7 @@ class TwitchUserDataObjectMother private constructor() {
                 userId = userId
             )
         }
-        fun addUserType(userType:String)=apply{
+        fun addUserType(userType:String?)=apply{
             twitchUserData = twitchUserData.copy(
                 userType = userType
             )
@@ -126,6 +127,11 @@ class TwitchUserDataObjectMother private constructor() {
         fun addBannedDuration(bannedDuration:Int)=apply{
             twitchUserData = twitchUserData.copy(
                 bannedDuration = bannedDuration
+            )
+        }
+        fun addSystemMessage(systemMessage:String)= apply{
+            twitchUserData = twitchUserData.copy(
+                systemMessage = systemMessage
             )
         }
 

--- a/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
+++ b/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
@@ -1,5 +1,6 @@
 package com.example.clicker
 
+import com.example.clicker.network.websockets.MessageType
 import com.example.clicker.network.websockets.ParsingEngine
 import com.example.clicker.util.objectMothers.LoggedInUserDataObjectMother
 import com.example.clicker.util.objectMothers.TwitchUserDataObjectMother
@@ -8,6 +9,7 @@ import org.junit.Test
 
 class ParsingEngineTest {
     val underTest:ParsingEngine = ParsingEngine()
+    val EXPECTED_NON_LATIN_BASED_USERNAME = "不橋小結"
 
     @Test
     fun testing_clear_chat_parsing_clear_chat_command(){
@@ -110,5 +112,48 @@ class ParsingEngineTest {
 
         /* Then */
         Assert.assertEquals(EXPECTED_MSG_ID, result )
+    }
+
+    @Test
+    fun user_notice_parsing_no_personal_message(){
+        /* Given */
+        val streamerName ="hasanabi"
+        val EXPECTED_USERNAME = "Bob34t4"
+        val EXPECTED_SYSTEM_MESSAGE ="CoalTheTroll subscribed with Prime. They've subscribed for 25 months!"
+        val EXPECTED_MESSAGE_ID = "submysterygift"
+        val parsingString ="@badge-info=subscriber/25;badges=subscriber/24,premium/1;color=#008000;display-name=$EXPECTED_USERNAME;emotes=;flags=;id=3ceab6bd-de3f-4d05-8038-5cebdb2af1c7;login=coalthetroll;mod=0;msg-id=$EXPECTED_MESSAGE_ID;msg-param-cumulative-months=25;msg-param-months=0;msg-param-multimonth-duration=0;msg-param-multimonth-tenure=0;msg-param-should-share-streak=0;msg-param-sub-plan-name=Woke\\sBeys\\s(hasanpiker):\\s\$4.99\\sSub;msg-param-sub-plan=Prime;msg-param-was-gifted=false;room-id=207813352;subscriber=1;system-msg=CoalTheTroll\\ssubscribed\\swith\\sPrime.\\sThey've\\ssubscribed\\sfor\\s25\\smonths!;tmi-sent-ts=1696621315536;user-id=73777153;user-type=;vip=0 :tmi.twitch.tv USERNOTICE #hasanabi"
+
+        /* Given */
+        val result = underTest.userNoticeParsing(parsingString,streamerName)
+
+        /* Then */
+        Assert.assertEquals(MessageType.MYSTERYGIFTSUB, result.messageType )
+        Assert.assertEquals(EXPECTED_USERNAME, result.displayName )
+        Assert.assertEquals(EXPECTED_SYSTEM_MESSAGE, result.userType )
+
+
+    }
+
+    @Test
+    fun user_notice_parsing_with_personal_message(){
+        /* Given */
+        val streamerName ="hasanabi"
+        val EXPECTED_MESSAGE ="yo <3"
+        val EXPECTED_USERNAME = "Bob34t4"
+        val EXPECTED_SYSTEM_MESSAGE ="CoalTheTroll subscribed with Prime. They've subscribed for 25 months!"
+        val EXPECTED_MESSAGE_ID = "submysterygift"
+        val parsingString ="@badge-info=subscriber/25;badges=subscriber/24,premium/1;color=#008000;display-name=$EXPECTED_USERNAME;emotes=;flags=;id=3ceab6bd-de3f-4d05-8038-5cebdb2af1c7;login=coalthetroll;mod=0;msg-id=$EXPECTED_MESSAGE_ID;msg-param-cumulative-months=25;msg-param-months=0;msg-param-multimonth-duration=0;msg-param-multimonth-tenure=0;msg-param-should-share-streak=0;msg-param-sub-plan-name=Woke\\sBeys\\s(hasanpiker):\\s\$4.99\\sSub;msg-param-sub-plan=Prime;msg-param-was-gifted=false;room-id=207813352;subscriber=1;system-msg=CoalTheTroll\\ssubscribed\\swith\\sPrime.\\sThey've\\ssubscribed\\sfor\\s25\\smonths!;tmi-sent-ts=1696621315536;user-id=73777153;user-type=;vip=0 :tmi.twitch.tv USERNOTICE #$streamerName :$EXPECTED_MESSAGE"
+
+        /* Given */
+        val result = underTest.userNoticeParsing(parsingString,streamerName)
+
+        /* Then */
+        Assert.assertEquals(MessageType.MYSTERYGIFTSUB, result.messageType )
+        Assert.assertEquals(EXPECTED_USERNAME, result.displayName )
+        Assert.assertEquals(EXPECTED_MESSAGE, result.userType )
+        Assert.assertEquals(EXPECTED_SYSTEM_MESSAGE, result.systemMessage )
+
+
+
     }
 }


### PR DESCRIPTION
# Related Issue
- #329 


# Proposed changes
- entirely reworked the USERNOTICE parsing into the engine. It is a lot simpler and does not parse as much as it use to. However, it does parse everything we need
- Tested the new parsing methods
- moved the TwitchUserData object 

# Additional context(optional)
- Now we can move on to PRIVMSG parsing, which is probably going to be the hardest
