### PR TITLE
adding the privateMessage parsing to the engine

### DIFF
--- a/app/src/main/java/com/example/clicker/network/websockets/ParsingEngine.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/ParsingEngine.kt
@@ -237,6 +237,12 @@ class ParsingEngine {
             .build()
     }
 
+    /**
+     * Creates a [TwitchUserData] that will be sent when a USERNOTICE command is sent
+     *
+     * @return a [TwitchUserData] used to notify the chat that an certain event has occurred. Example events are,
+     * announcement, resub, sub, submysterygift, subgift
+     */
     fun userNoticeParsing(text: String,streamerChannelName: String): TwitchUserData {
 
         val displayNamePattern = "display-name=([^;]+)".toRegex()
@@ -271,6 +277,45 @@ class ParsingEngine {
             .addUserType(personalMessage)
             .addSystemMessage(systemMessage)
             .build()
+
+    }
+
+    fun privateMessageParsing(text:String):TwitchUserData{
+        val pattern = "([^;@]+)=([^;]+)".toRegex()
+        val privateMsgPattern = "([^:]+)$".toRegex()
+
+        val matchResults = pattern.findAll(text)
+        val privateMsgResult = privateMsgPattern.find(text)
+
+        val parsedData = mutableMapOf<String, String>()
+        val privateMsg = privateMsgResult?.groupValues?.get(1) ?: ""
+
+
+        for (matchResult in matchResults) {
+            val (key, value) = matchResult.destructured
+            parsedData[key] = value
+        }
+
+        return TwitchUserData(
+            badgeInfo = parsedData["badge-info"],
+            badges = parsedData["badges"],
+            clientNonce = parsedData["client-nonce"],
+            color = parsedData["color"] ?: "#000000",
+            displayName = parsedData["display-name"],
+            emotes = parsedData["emotes"],
+            firstMsg = parsedData["first-msg"],
+            flags = parsedData["flags"],
+            id = parsedData["id"],
+            mod = parsedData["mod"],
+            returningChatter = parsedData["returning-chatter"],
+            subscriber = parsedData["subscriber"]?.toIntOrNull() == 1,
+            roomId = parsedData["room-id"],
+            tmiSentTs = parsedData["tmi-sent"]?.toLongOrNull(),
+            turbo = parsedData["turbo"]?.toIntOrNull() == 1,
+            userType = privateMsg,
+            userId = parsedData["user-id"],
+            messageType = MessageType.USER
+        )
 
     }
 

--- a/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/TwitchWebSocket.kt
@@ -30,33 +30,7 @@ enum class MessageType {
     USER, NOTICE,USERNOTICE,ANNOUNCEMENT,RESUB,SUB,MYSTERYGIFTSUB,GIFTSUB,ERROR,JOIN,CLEARCHAT
 }
 
-data class TwitchUserAnnouncement(
-    val badgeInfo: String,
-    val badges: String,
-    val color: String,
-    val displayName: String,
-    val emotes: String,
-    val flags: String,
-    val id: String,
-    val login: String,
-    val mod: Int,
-    val msgId: String,
-    val msgParamCumulativeMonths: Int,
-    val msgParamMonths: Int,
-    val msgParamMultimonthDuration: Int,
-    val msgParamMultimonthTenure: Int,
-    val msgParamShouldShareStreak: Int,
-    val msgParamStreakMonths: Int,
-    val msgParamSubPlanName: String,
-    val msgParamSubPlan: String,
-    val msgParamWasGifted: Boolean,
-    val roomId: Long,
-    val subscriber: Int,
-    val systemMsg: String,
-    val tmiSentTs: Long,
-    val userId: Long,
-    val userType: String
-)
+
 
 
 
@@ -241,8 +215,9 @@ class TwitchWebSocket @Inject constructor(
 
          if(text.contains("PRIVMSG")){
              Log.d("loggedInDataOnMessage","PRIVMSG --> $text")
-             val anotherTesting = parseStringBaby(text)
-             val mappedString = mapToTwitchUserData(anotherTesting, sentMessage = sentMessageString)
+//             val anotherTesting = parseStringBaby(text)
+//             val mappedString = mapToTwitchUserData(anotherTesting, sentMessage = sentMessageString)
+              val mappedString = ParsingEngine().privateMessageParsing(text)
              _state.tryEmit(mappedString)
          }
 
@@ -319,62 +294,6 @@ class TwitchWebSocket @Inject constructor(
 
 }/*********END OF THE TwitchWebSocket CLASS*******/
 
-
-fun parseStringBaby(input: String): Map<String, String> {
-    val pattern = "([^;@]+)=([^;]+)".toRegex()
-    val matchResults = pattern.findAll(input)
-
-    val parsedData = mutableMapOf<String, String>()
-
-
-    for (matchResult in matchResults) {
-        val (key, value) = matchResult.destructured
-        parsedData[key] = value
-    }
-
-    return parsedData
-}
-
-fun mapToTwitchUserData(parsedData: Map<String, String>,sentMessage: String): TwitchUserData {
-    return TwitchUserData(
-        badgeInfo = parsedData["badge-info"],
-        badges = parsedData["badges"],
-        clientNonce = parsedData["client-nonce"],
-        color = parsedData["color"] ?: "#000000",
-        displayName = parsedData["display-name"],
-        emotes = parsedData["emotes"],
-        firstMsg = parsedData["first-msg"],
-        flags = parsedData["flags"],
-        id = parsedData["id"],
-        mod = parsedData["mod"],
-        returningChatter = parsedData["returning-chatter"],
-        subscriber = parsedData["subscriber"]?.toIntOrNull() == 1,
-        roomId = parsedData["room-id"],
-        tmiSentTs = parsedData["tmi-sent"]?.toLongOrNull(),
-        turbo = parsedData["turbo"]?.toIntOrNull() == 1,
-        userType = checkStrings(filterText(parsedData["user-type"].toString()),sentMessage),
-        userId = parsedData["user-id"],
-        messageType = MessageType.USER
-    )
-}
-
-fun checkStrings(parsedText:String,sentMessage:String):String{
-    if(parsedText.isEmpty()){
-        return sentMessage
-    }else{
-        return parsedText
-    }
-}
-
-
-fun filterText(chatText:String):String{
-
-    val regex = ":(.*?):(.*)".toRegex()
-    val matchResult = regex.find(chatText)
-    //Log.d("websocketStoofs","onMessageLoggers-> $streamerName")
-
-    return matchResult?.groupValues?.getOrNull(2)?.trim() ?: ""
-}
 
 
 

--- a/app/src/main/java/com/example/clicker/network/websockets/models/DataClases.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/models/DataClases.kt
@@ -78,3 +78,37 @@ data class TwitchUserData(
     val bannedDuration:Int? = null,
     val systemMessage:String? = null
 )
+
+/**
+ * DEPRECIATED
+ *
+ * This was originally used for parsing a USERNOTICE message. However, I no longer user it and I
+ * don't want to delete it encase I have to use it again
+ */
+data class TwitchUserAnnouncement(
+    val badgeInfo: String,
+    val badges: String,
+    val color: String,
+    val displayName: String,
+    val emotes: String,
+    val flags: String,
+    val id: String,
+    val login: String,
+    val mod: Int,
+    val msgId: String,
+    val msgParamCumulativeMonths: Int,
+    val msgParamMonths: Int,
+    val msgParamMultimonthDuration: Int,
+    val msgParamMultimonthTenure: Int,
+    val msgParamShouldShareStreak: Int,
+    val msgParamStreakMonths: Int,
+    val msgParamSubPlanName: String,
+    val msgParamSubPlan: String,
+    val msgParamWasGifted: Boolean,
+    val roomId: Long,
+    val subscriber: Int,
+    val systemMsg: String,
+    val tmiSentTs: Long,
+    val userId: Long,
+    val userType: String
+)

--- a/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
+++ b/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
@@ -156,4 +156,25 @@ class ParsingEngineTest {
 
 
     }
+    @Test
+    fun private_message_parsing(){
+        /* Given */
+
+        val EXPECTED_MESSAGE ="GIGACHAD"
+        val LONGER_EXPECTED_MESSAGE="@NotTooBadAye same was just thinking the same thing"
+
+        val parsingString ="@badge-info=;badges=premium/1;client-nonce=3630d7e4c765758191175beaf3929b33;color=;display-name=FemboyQtx;emotes=;first-msg=1;flags=;id=d2c1740e-aab5-4428-9b45-5ca049e7e669;mod=0;returning-chatter=0;room-id=26610234;subscriber=0;tmi-sent-ts=1696686131397;turbo=0;user-id=816961592;user-type= :femboyqtx!femboyqtx@femboyqtx.tmi.twitch.tv PRIVMSG #cohhcarnage :$EXPECTED_MESSAGE"
+        val longerParsingString ="@badge-info=;badges=premium/1;client-nonce=3110c13339efbb8bf9e2c10c9951de6d;color=#8A2BE2;display-name=PixelWhip;emotes=;first-msg=0;flags=;id=1df2a3a7-7ab7-42a3-882c-836cea92f377;mod=0;reply-parent-display-name=NotTooBadAye;reply-parent-msg-body=this\\sgame\\sreminds\\sme\\sof\\sNeopets;reply-parent-msg-id=43eb8d7d-4584-4777-9b14-fc6479637b20;reply-parent-user-id=72807154;reply-parent-user-login=nottoobadaye;reply-thread-parent-msg-id=43eb8d7d-4584-4777-9b14-fc6479637b20;reply-thread-parent-user-login=nottoobadaye;returning-chatter=0;room-id=26610234;subscriber=0;tmi-sent-ts=1696686129437;turbo=0;user-id=66065436;user-type= :pixelwhip!pixelwhip@pixelwhip.tmi.twitch.tv PRIVMSG #cohhcarnage :$LONGER_EXPECTED_MESSAGE"
+
+        /* Given */
+        val result = underTest.privateMessageParsing(longerParsingString)
+
+        /* Then */
+        Assert.assertEquals(LONGER_EXPECTED_MESSAGE, result.userType )
+
+
+
+
+    }
+
 }


### PR DESCRIPTION
# Related Issue
- #331 


# Proposed changes
- moved the PRIVMSG parsing code into the engine and tested it


# Additional context(optional)
- Now we can move onto the final ROOMSTATE parsing
