### PR TITLE
removing the datastoreViewModel token validation

### DIFF
--- a/app/src/main/java/com/example/clicker/network/repository/TwitchRepoImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchRepoImpl.kt
@@ -24,6 +24,7 @@ class TwitchRepoImpl @Inject constructor(
     private val twitchClient: TwitchClient
 ): TwitchRepo {
 
+
     override suspend fun validateToken(token:String):Flow<Response<ValidatedUser>> = flow{
         logCoroutineInfo("CoroutineDebugging","Fetching from remote")
 

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeFragment.kt
@@ -74,7 +74,6 @@ class HomeFragment : Fragment() {
                     streamViewModel = streamViewModel,
                     loginWithTwitch = {startActivity(twitchIntent)},
                     onNavigate = { dest -> findNavController().navigate(dest) },
-                    dataStoreViewModel = dataStoreViewModel,
                     workerViewModel = workerViewModel
 
                 )

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
@@ -85,7 +85,6 @@ fun HomeView(
     streamViewModel: StreamViewModel,
     loginWithTwitch:() -> Unit,
     onNavigate: (Int) -> Unit,
-    dataStoreViewModel:DataStoreViewModel,
     workerViewModel:WorkerViewModel
 ){
     val hideModal = homeViewModel.state.value.hideModal
@@ -104,8 +103,7 @@ fun HomeView(
 
 
 
-    val validationStatus = dataStoreViewModel.showLogin.value
-    val authState = dataStoreViewModel.state.value.authState
+
     var state by remember { mutableIntStateOf(0) }
 
     val pagerState = rememberPagerState(pageCount = {

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -69,6 +69,18 @@ class HomeViewModel @Inject constructor(
 ): ViewModel(){
 
 
+    init{
+//        viewModelScope.launch {
+//            withContext( CoroutineName("TokenValidatorDebugging")){
+//                twitchRepoImpl.validateToken("").collect{
+//                    logCoroutineInfo("CoroutineDebugging","GOT ITEMS from remote")
+//
+//
+//                }
+//            }
+//
+//        }
+    }
 
 
     private val _newUrlList =MutableStateFlow<List<StreamInfo>?>(null)


### PR DESCRIPTION
# Related Issue
- n/a


# Proposed changes
- I just removed the useless calls to datastoreViewModel as I am no longer using it


# Additional context(optional)
- There was no related issue because this was just something I found while using the coroutine debugger
