### PR TITLE
adding dark mode to for api less than 31

### DIFF
--- a/app/src/main/java/com/example/clicker/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/clicker/ui/theme/Color.kt
@@ -19,5 +19,5 @@ val md_theme_light_onSecondary = Color(0xFFFFFFFF)
 
 val md_theme_dark_primary = Color(0xff444444)
 val md_theme_dark_onPrimary = Color(0xFFFFFFFF)
-val md_theme_dark_secondary = Color(0xFFFF0000)
+val md_theme_dark_secondary = Color(0xFF6650a4)
 val md_theme_dark_onSecondary = Color(0xFFFFFFFF)

--- a/app/src/main/java/com/example/clicker/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/clicker/ui/theme/Theme.kt
@@ -1,6 +1,7 @@
 package com.example.clicker.ui.theme
 
 
+import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -28,10 +29,16 @@ fun AppTheme(
     useDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable() () -> Unit
 ) {
-    val colors = if (!useDarkTheme) {
-        LightColors
-    } else {
-        DarkColors
+//    val colors = if (!useDarkTheme) {
+//        LightColors
+//    } else {
+//        DarkColors
+//    }
+//
+    val colors = when{
+        (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) -> DarkColors
+        (!useDarkTheme) -> LightColors
+        else -> DarkColors
     }
 
     MaterialTheme(


### PR DESCRIPTION
# Related Issue
- #442 


# Proposed changes
- changing the secondary color on dark theme 
- using `Build.VERSION.SDK_INT < Build.VERSION_CODES.S` to make the default theme to dark for api less than 31


# Additional context(optional)
- n/a
