### PR TITLE
fixing the parsing bug for notice star messages

### DIFF
--- a/app/src/main/java/com/example/clicker/network/websockets/ParsingEngine.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/ParsingEngine.kt
@@ -144,16 +144,30 @@ class ParsingEngine @Inject constructor() {
     }
 
     fun noticeParsing(text: String, streamerChannelName: String): TwitchUserData {
-        val pattern = "#$streamerChannelName\\s*:(.+)".toRegex()
-        val matchResult = pattern.find(text)
-        val extractedInfo = matchResult?.groupValues?.get(1)?.trim() ?: "Room information updated"
+        if(text.contains("NOTICE *")){
+            val regexPattern ="(NOTICE \\* :)(.+)".toRegex()
+            val matchedPattern= regexPattern.find(text)?.groupValues?.get(2) ?: "Room information updated"
+            return TwitchUserDataObjectMother
+                .addColor("#000000")
+                .addDisplayName("Room update")
+                .addUserType(matchedPattern)
+                .addMessageType(MessageType.NOTICE)
+                .build()
 
-        return TwitchUserDataObjectMother
-            .addColor("#000000")
-            .addDisplayName("Room update")
-            .addUserType(extractedInfo)
-            .addMessageType(MessageType.NOTICE)
-            .build()
+        }else{
+            val pattern = "#$streamerChannelName\\s*:(.+)".toRegex()
+            val matchResult = pattern.find(text)
+            val extractedInfo = matchResult?.groupValues?.get(1)?.trim() ?: "Room information updated"
+            return TwitchUserDataObjectMother
+                .addColor("#000000")
+                .addDisplayName("Room update")
+                .addUserType(extractedInfo)
+                .addMessageType(MessageType.NOTICE)
+                .build()
+        }
+
+
+
     }
 
     /**

--- a/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
+++ b/app/src/test/java/com/example/clicker/ParsingEngineTest.kt
@@ -181,4 +181,19 @@ class ParsingEngineTest {
         /* THEN */
         Assert.assertEquals(expectedResult, actualResult)
     }
+    @Test
+    fun star_notice_testing(){
+        /* Given */
+        val expectedResult="Login authentication failed"
+        val testText = ":tmi.twitch.tv NOTICE * :$expectedResult"
+
+        /* When */
+        // so we need to match everything after this patter, #tru3ta1ent :
+
+        val actualResult = underTest.noticeParsing(testText,"channelName").userType
+
+
+        /* THEN */
+        Assert.assertEquals(expectedResult, actualResult)
+    }
 }


### PR DESCRIPTION
# Related Issue
- #453 


# Proposed changes
- added changes to the notice parsing method. 
- it now can parse messages that are sent without a channel username and just a star, `NOTICE *`


# Additional context(optional)
- any additional information neccessary 
