### PR TITLE
side chat autoscrolling now working'

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -966,7 +966,7 @@ fun TextChat(
                 }
             }
 
-            items(twitchUserChat,key = { twitchUser -> twitchUser.id!!}) { twitchUser ->
+            items(twitchUserChat) { twitchUser ->
 
                 val color = Color(parseColor(twitchUser.color))
 
@@ -1509,9 +1509,7 @@ fun ChatCard(
     if(color == Color.Black){
         color = androidx.compose.material3.MaterialTheme.colorScheme.primary
     }
-    var displayName by remember { mutableStateOf(twitchUser.displayName) }
-    var comment by remember { mutableStateOf(twitchUser.userType) }
-    var showIcons by remember { mutableStateOf(true) }
+
     val state = rememberSwipeableActionsState()
 
     val offset = state.offset.value
@@ -1520,7 +1518,6 @@ fun ChatCard(
 
     val thresholdCrossed = abs(offset) > swipeThresholdPx
 
-    // val backgroundColor = Color.Black
     var backgroundColor by remember { mutableStateOf(Color.Black) }
     var fontSize = 17.sp
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -173,11 +173,17 @@ class StreamViewModel @Inject constructor(
     // this should be hooked up to a hot flow and run eachtime a new messageId is sent to it
     //todo:chat method
     fun filterMessages(messageId: String) {
-        val found = listChats.first { it.id == messageId }
-        val foundIndex = listChats.indexOf(found)
-        listChats[foundIndex] = found.copy(
-            deleted = true
-        )
+        try{
+            val found = listChats.first { it.id == messageId }
+            val foundIndex = listChats.indexOf(found)
+            listChats[foundIndex] = found.copy(
+                deleted = true
+            )
+        }catch (e:Exception){
+            Log.d("FilterMessageCrash","messageId-----> $messageId")
+            Log.d("FilterMessageCrash","messageId-----> ${e.message}")
+        }
+
     }
     //chat method
     private fun banUserFilter(username: String, banDuration: Int?) {


### PR DESCRIPTION
# Related Issue
- #470


# Proposed changes
- Side chat with autoscrolling is now implemented.
- also, this is a far better way to layout the composable functions. I personally like this:
```
       ChatList(
            twitchUserChat,
            lazyColumnListState = lazyColumnListState,
            autoscroll = autoscroll,
            changeAutoScroll = {value -> autoscroll = value}
        )
        EnterChatBox(
            modifier =Modifier.align(Alignment.BottomCenter),
            textFieldValue = streamViewModel.textFieldValue,
            filterMethod = {text,character,index ->streamViewModel.filterMethodBetter(text,character,index)},
            filteredChatList = streamViewModel.filteredChatList,
            clickedAutoCompleteText= { text, username -> streamViewModel.autoTextChange(text,username) }
        )
        ScrollToBottomButton(
            scrollingPaused = !autoscroll,
            enableAutoScroll = { autoscroll = true },
            modifier =Modifier.align(Alignment.BottomCenter)
        )
```
- very clean looking.... compared to the vertical chat


# Additional context(optional)
- now we can move on to the dragging functionality
