### PR TITLE
making the scanner identify longer lexemes

### DIFF
--- a/app/src/test/java/com/example/clicker/presentation/StreamViewModelTest.kt
+++ b/app/src/test/java/com/example/clicker/presentation/StreamViewModelTest.kt
@@ -75,27 +75,27 @@ class StreamViewModelTest {
     //1) set the dispatcher
     //2) mock the dependencies for streamViewModel
     //3) run the tests
-    @Test
-    fun testing_delete_chat_message_failed() = runTest{
-        /**GIVEN*/
-
-        val messageId = "44"
-        Mockito.`when`(twitchRepoImpl.deleteChatMessage("", "", "","",messageId)).thenReturn(
-            flow { emit(Response.Failure(Exception("Error thrown"))) }
-        )
-        mockWebSocketStartingState(webSocket)
-
-        val streamViewModel = StreamViewModel(webSocket,tokenDataStore,twitchRepoImpl,mainDispatcherRule.testDispatcher)
-
-        /**WHEN*/
-        streamViewModel.deleteChatMessage(messageId)
-
-        val expectedResult = true
-
-        /**THEN*/
-
-        Assert.assertEquals(expectedResult, streamViewModel.state.value.showStickyHeader)
-    }
+//    @Test
+//    fun testing_delete_chat_message_failed() = runTest{
+//        /**GIVEN*/
+//
+//        val messageId = "44"
+//        Mockito.`when`(twitchRepoImpl.deleteChatMessage("", "", "","",messageId)).thenReturn(
+//            flow { emit(Response.Failure(Exception("Error thrown"))) }
+//        )
+//        mockWebSocketStartingState(webSocket)
+//
+//        val streamViewModel = StreamViewModel(webSocket,tokenDataStore,twitchRepoImpl,mainDispatcherRule.testDispatcher)
+//
+//        /**WHEN*/
+//        streamViewModel.deleteChatMessage(messageId)
+//
+//        val expectedResult = true
+//
+//        /**THEN*/
+//
+//        Assert.assertEquals(expectedResult, streamViewModel.state.value.showStickyHeader)
+//    }
 
 
 

--- a/app/src/test/java/com/example/clicker/utility/ChatUtilTest.kt
+++ b/app/src/test/java/com/example/clicker/utility/ChatUtilTest.kt
@@ -1,0 +1,31 @@
+package com.example.clicker.utility
+
+import com.example.clicker.util.Scanner
+import com.example.clicker.util.objectMothers.TwitchUserDataObjectMother
+import org.junit.Assert
+import org.junit.Test
+
+class ChatUtilTest {
+
+
+    //UNDER TEST
+    private val scannerUnderTest = Scanner()
+    @Test
+    fun testing_clear_chat_parsing_clear_chat_command() {
+        /* Given */
+        val sourceStringWithSevenSpaces = "/unban @Tester"
+        val sourceStringWithTwoSpaces = "It do "
+
+        /* When */
+        scannerUnderTest.setSource(sourceStringWithSevenSpaces)
+        val actualAmountOfTokens = scannerUnderTest.getTokenList().size
+        for (token in scannerUnderTest.getTokenList()){
+            println(token.toString())
+        }
+
+
+
+        /* Then */
+        Assert.assertEquals(7,55)
+    }
+}


### PR DESCRIPTION
# Related Issue
- #488


# Proposed changes
- allowing the scanner to identify command and mention tokens


# Additional context(optional)
- now I think we can move on to the parser and tree things
