### PR TITLE
making the chat API cleaner

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/views/TwitchIRCSystemNotifications.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/TwitchIRCSystemNotifications.kt
@@ -30,57 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.clicker.R
 
-object TwitchIRCSystemNotificationsBuilder{
-    @Composable
-    fun SystemChat(
-        messageHeader:@Composable () -> Unit,
-        messageText:@Composable () -> Unit,
-    ){
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(Color.Black.copy(alpha = 0.6f))
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(15.dp)
-            ) {
-                messageHeader()
-                messageText()
-            }
-        }
-    }
-    @Composable
-    fun SystemChatAlert(
-        messageHeader:@Composable () -> Unit,
-        messageText:@Composable () -> Unit,
-        messageButton:@Composable () -> Unit,
-    ){
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(Color.Black.copy(alpha = 0.6f))
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(15.dp)
-            ) {
-                messageHeader()
-                messageText()
-                Row(modifier = Modifier
-                    .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center
-                ){
-                    messageButton()
-                }
 
-            }
-        }
-
-    }
-}
 object SystemChats {
 
     @Composable
@@ -232,136 +182,188 @@ object SystemChats {
         )
 
     }
-}
-
-object ChatMessagesParts{
-    @Composable
-    fun MessageHeader(
-        contentDescription:String,
-        iconImageVector: ImageVector,
-        message:String
-    ){
-        Icons.Default.Lock
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Start,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Icon(
-                imageVector = iconImageVector,
-                contentDescription =contentDescription,
+    private object TwitchIRCSystemNotificationsBuilder{
+        @Composable
+        fun SystemChat(
+            messageHeader:@Composable () -> Unit,
+            messageText:@Composable () -> Unit,
+        ){
+            Row(
                 modifier = Modifier
-                    .size(30.dp),
-                tint = Color.White
-            )
-            Text(message, color = Color.White, fontSize = 20.sp)
-        }
-    }
-    @Composable
-    fun MessageText(
-        message: String?,
-        systemMessage: String?
-    ){
-        val TwitchIRCMessage = systemMessage ?: ""
-        val personalMessage = message ?: ""
-        Text(
-            buildAnnotatedString {
-                withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
-                    append(" $TwitchIRCMessage")
-                    append(" $personalMessage")
+                    .fillMaxWidth()
+                    .background(Color.Black.copy(alpha = 0.6f))
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(15.dp)
+                ) {
+                    messageHeader()
+                    messageText()
                 }
             }
-        )
-    }
-    @Composable
-    fun NamedMessageText(
-        displayName: String?,
-        message: String?,
-        systemMessage: String?
-    ){
-        val personalMessage = message ?: ""
-        val twitchIRCMessage = systemMessage ?: ""
-        Text(
-            buildAnnotatedString {
-                withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
-                    append("$displayName :")
-                }
-                withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
-                    append(" $twitchIRCMessage")
-                    append(" $personalMessage")
+        }
+        @Composable
+        fun SystemChatAlert(
+            messageHeader:@Composable () -> Unit,
+            messageText:@Composable () -> Unit,
+            messageButton:@Composable () -> Unit,
+        ){
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.Black.copy(alpha = 0.6f))
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(15.dp)
+                ) {
+                    messageHeader()
+                    messageText()
+                    Row(modifier = Modifier
+                        .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center
+                    ){
+                        messageButton()
+                    }
+
                 }
             }
-        )
 
-    }
-
-    @Composable
-    fun SimpleText(message: String){
-        Text(message,
-            fontSize = 17.sp,
-            color = androidx.compose.material3.MaterialTheme.colorScheme.onPrimary,
-            modifier = Modifier.padding(start = 5.dp)
-        )
-    }
-    @Composable
-    fun AlertHeader(
-        alertMessage:String,
-        alertIcon:ImageVector
-    ){
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Icon(
-                imageVector = alertIcon,
-                contentDescription = stringResource(R.string.warning_icon_description),
-                modifier = Modifier
-                    .size(30.dp),
-                tint = Color.Red
-            )
-            Text(alertMessage, color = Color.Red, fontSize = 20.sp, modifier = Modifier.padding(horizontal = 10.dp))
-            Icon(
-                imageVector = alertIcon,
-                contentDescription = stringResource(R.string.warning_icon_description),
-                modifier = Modifier
-                    .size(30.dp),
-                tint = Color.Red
-            )
         }
     }
 
-    @Composable
-    fun ButtonWithText(
-        buttonAction: () -> Unit,
-        buttonText:String,
-    ){
-        Button(
-            onClick = { buttonAction() },
-            colors = ButtonDefaults.buttonColors(backgroundColor = Color.DarkGray)
-        ) {
-            Text(buttonText, color = Color.White)
+    private object ChatMessagesParts{
+        @Composable
+        fun MessageHeader(
+            contentDescription:String,
+            iconImageVector: ImageVector,
+            message:String
+        ){
+            Icons.Default.Lock
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    imageVector = iconImageVector,
+                    contentDescription =contentDescription,
+                    modifier = Modifier
+                        .size(30.dp),
+                    tint = Color.White
+                )
+                Text(message, color = Color.White, fontSize = 20.sp)
+            }
         }
-    }
-
-    @Composable
-    fun UserSpecificText(
-        color: Color,
-        displayName: String?,
-        message: String?
-    ){
-        Text(
-            buildAnnotatedString {
-                withStyle(style = SpanStyle(color = color, fontSize = 17.sp)) {
-                    append("$displayName :")
+        @Composable
+        fun MessageText(
+            message: String?,
+            systemMessage: String?
+        ){
+            val TwitchIRCMessage = systemMessage ?: ""
+            val personalMessage = message ?: ""
+            Text(
+                buildAnnotatedString {
+                    withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
+                        append(" $TwitchIRCMessage")
+                        append(" $personalMessage")
+                    }
                 }
-                append(" $message")
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(15.dp),
-            color = Color.White
-        )
-    }
+            )
+        }
+        @Composable
+        fun NamedMessageText(
+            displayName: String?,
+            message: String?,
+            systemMessage: String?
+        ){
+            val personalMessage = message ?: ""
+            val twitchIRCMessage = systemMessage ?: ""
+            Text(
+                buildAnnotatedString {
+                    withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
+                        append("$displayName :")
+                    }
+                    withStyle(style = SpanStyle(color = Color.White, fontSize = 17.sp)) {
+                        append(" $twitchIRCMessage")
+                        append(" $personalMessage")
+                    }
+                }
+            )
 
+        }
+
+        @Composable
+        fun SimpleText(message: String){
+            Text(message,
+                fontSize = 17.sp,
+                color = androidx.compose.material3.MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.padding(start = 5.dp)
+            )
+        }
+        @Composable
+        fun AlertHeader(
+            alertMessage:String,
+            alertIcon:ImageVector
+        ){
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    imageVector = alertIcon,
+                    contentDescription = stringResource(R.string.warning_icon_description),
+                    modifier = Modifier
+                        .size(30.dp),
+                    tint = Color.Red
+                )
+                Text(alertMessage, color = Color.Red, fontSize = 20.sp, modifier = Modifier.padding(horizontal = 10.dp))
+                Icon(
+                    imageVector = alertIcon,
+                    contentDescription = stringResource(R.string.warning_icon_description),
+                    modifier = Modifier
+                        .size(30.dp),
+                    tint = Color.Red
+                )
+            }
+        }
+
+        @Composable
+        fun ButtonWithText(
+            buttonAction: () -> Unit,
+            buttonText:String,
+        ){
+            Button(
+                onClick = { buttonAction() },
+                colors = ButtonDefaults.buttonColors(backgroundColor = Color.DarkGray)
+            ) {
+                Text(buttonText, color = Color.White)
+            }
+        }
+
+        @Composable
+        fun UserSpecificText(
+            color: Color,
+            displayName: String?,
+            message: String?
+        ){
+            Text(
+                buildAnnotatedString {
+                    withStyle(style = SpanStyle(color = color, fontSize = 17.sp)) {
+                        append("$displayName :")
+                    }
+                    append(" $message")
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(15.dp),
+                color = Color.White
+            )
+        }
+
+    }
 }
+


### PR DESCRIPTION
# Related Issue
- #542


# Proposed changes
- moving around the code to all remain inside of the `SystemChats ` object expression. Making it so outside code only has access to the code we want it to have access to.


# Additional context(optional)
- n/a
