### PR TITLE
fixing the rotation bug with hardcoding

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeFragment.kt
@@ -2,6 +2,7 @@ package com.example.clicker.presentation.home
 
 import android.app.Activity
 import android.content.Intent
+import android.content.res.Configuration
 import android.content.res.Resources
 import android.graphics.Insets
 import android.net.Uri
@@ -51,7 +52,9 @@ class HomeFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val currentOrientation = getResources().getConfiguration().orientation;
     }
+
 
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
@@ -164,7 +167,7 @@ class HomeFragment : Fragment() {
         val width = Resources.getSystem().displayMetrics.widthPixels / 2
         val aspectHeight = (width * 0.5625).toInt()
 
-        homeViewModel.updateAspectWidthHeight(width, aspectHeight,screenDensity)
+        homeViewModel.updateAspectWidthHeight(540, 303,screenDensity)
 
         Log.d("Twitchval", "uri -> $uri")
 
@@ -177,6 +180,5 @@ class HomeFragment : Fragment() {
             authenticationViewModel.setOAuthToken(authCode)
         }
     }
-    fun launchCustomTab() {
-    }
+
 }

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -191,15 +191,27 @@ class HomeViewModel @Inject constructor(
     }
 
     fun updateAspectWidthHeight(width: Int, aspectHeight: Int,screenDensity:Float) {
+
         _uiState.value = _uiState.value.copy(
             aspectHeight = aspectHeight,
             width = width,
             screenDensity =screenDensity
         )
     }
+    fun updateUrlWidthHeight(aspectWidth: Int, aspectHeight: Int){
+        val replacedWidthHeightList = _newUrlList.value?.map {
+            it.changeUrlWidthHeight(
+                aspectWidth,
+                aspectHeight
+            )
+        }
+
+        _newUrlList.tryEmit(replacedWidthHeightList)
+    }
 }
 
 fun StreamInfo.changeUrlWidthHeight(aspectWidth: Int, aspectHeight: Int): StreamInfo {
+
     return StreamInfo(
         streamerName = this.streamerName,
         streamTitle = this.streamTitle,


### PR DESCRIPTION
# Related Issue
- #662


# Proposed changes
- fixed the rotation bug by hardcoding width and height values. This works for now but might look odd when it comes to larger screens. I will deal with that problem when I start to design for large screens.


# Additional context(optional)
- n/a
