### PR TITLE
popping the back stack for navigation

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/modChannels/ModChannelView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/ModChannelView.kt
@@ -32,7 +32,7 @@ import com.example.clicker.presentation.modChannels.views.ModChannelComponents
 @Composable
 fun ModChannelView(
     homeViewModel: HomeViewModel,
-    onNavigate: (Int) -> Unit,
+    onNavigate: () -> Unit,
 ){
     val bottomModalState = rememberModalBottomSheetState(ModalBottomSheetValue.Expanded)
 
@@ -44,7 +44,7 @@ fun ModChannelView(
     ) {
 
         ModChannelComponents.MainModView(
-            onNavigate = { destination -> onNavigate(destination) },
+            onNavigate = { onNavigate() },
             height = homeViewModel.state.value.aspectHeight,
             width = homeViewModel.state.value.width,
             density = homeViewModel.state.value.screenDensity,

--- a/app/src/main/java/com/example/clicker/presentation/modChannels/ModChannelsFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/ModChannelsFragment.kt
@@ -40,6 +40,7 @@ class ModChannelsFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
+
         _binding = FragmentModChannelsBinding.inflate(inflater, container, false)
         val view = binding.root
         binding.composeView.apply {
@@ -47,7 +48,7 @@ class ModChannelsFragment : Fragment() {
             setContent {
                 AppTheme{
                     ModChannelView(
-                        onNavigate = { dest -> findNavController().navigate(dest) },
+                        onNavigate = {  findNavController().popBackStack() },
                         homeViewModel = homeViewModel
                     )
                 }

--- a/app/src/main/java/com/example/clicker/presentation/modChannels/views/MainComponents.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/views/MainComponents.kt
@@ -96,7 +96,7 @@ object ModChannelComponents{
      * */
     @Composable
     fun MainModView(
-        onNavigate: (Int) -> Unit,
+        onNavigate: () -> Unit,
         height: Int,
         width: Int,
         density:Float,
@@ -109,12 +109,12 @@ object ModChannelComponents{
         Builders.ScaffoldBuilder(
             topBar = {
                 Parts.CustomTopBar(
-                    onNavigate ={destination -> onNavigate(destination)}
+                    onNavigate ={ onNavigate()}
                 )
             },
             bottomBar={
                 Parts.CustomBottomBar(
-                    onNavigate ={destination -> onNavigate(destination)}
+                    onNavigate ={ onNavigate()}
                 )
             },
             pullToRefreshList = {contentPadding ->
@@ -651,7 +651,7 @@ object ModChannelComponents{
          * */
         @Composable
         fun CustomTopBar(
-            onNavigate: (Int) -> Unit
+            onNavigate: () -> Unit
         ) {
             Column(
                 modifier = Modifier
@@ -668,7 +668,8 @@ object ModChannelComponents{
                         modifier = Modifier
                             .size(35.dp)
                             .clickable {
-                                onNavigate(R.id.action_modChannelsFragment_to_homeFragment)
+                               // onNavigate(R.id.action_modChannelsFragment_to_homeFragment)
+                                onNavigate()
                             },
                         tint = MaterialTheme.colorScheme.onSecondary
                     )
@@ -691,7 +692,7 @@ object ModChannelComponents{
          * */
         @Composable
         fun CustomBottomBar(
-            onNavigate: (Int) -> Unit,
+            onNavigate: () -> Unit,
         ){
             Row(
                 modifier = Modifier
@@ -703,7 +704,10 @@ object ModChannelComponents{
             ){
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier=Modifier.clickable { onNavigate(R.id.action_modChannelsFragment_to_homeFragment) }
+                    modifier=Modifier.clickable {
+                        //onNavigate(R.id.action_modChannelsFragment_to_homeFragment)
+                        onNavigate()
+                    }
                 ) {
                     Icon(
                         imageVector = Icons.Default.Home,


### PR DESCRIPTION
# Related Issue
- #711


# Proposed changes
- changed the navigation on modChannels from `onNavigate = { dest -> findNavController().navigate(dest) }` to `onNavigate = { findNavController().popBackStack() }`



# Additional context(optional)
- n/a
