### PR TITLE
adding the UI for the network error

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
@@ -153,8 +153,6 @@ fun ValidationView(
         urlList =homeViewModel.newUrlList.collectAsState().value,
         clientId = homeViewModel.validatedUser?.clientId ?: "",
         userId = homeViewModel.validatedUser?.userId ?: "",
-        showFailedNetworkRequestMessage = homeViewModel.state.value.failedNetworkRequest,
-        failedNetworkRequestMessage =homeViewModel.state.value.failedNetworkRequestMessage,
         height = homeViewModel.state.value.aspectHeight,
         width = homeViewModel.state.value.width,
         logout = {
@@ -168,7 +166,7 @@ fun ValidationView(
         homeRefreshing =homeViewModel.state.value.homeRefreshing,
         homeRefreshFunc = {homeViewModel.pullToRefreshGetLiveStreams()},
         networkMessageColor=Color.Red,
-        networkMessage ="Disconnected from network",
+        networkMessage =homeViewModel.state.value.homeNetworkErrorMessage,
         showNetworkMessage = homeViewModel.state.value.networkConnectionState
 
 

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -60,10 +60,6 @@ data class HomeUIState(
     val width: Int = 0,
     val aspectHeight: Int = 0,
     val screenDensity: Float = 0f,
-
-
-    val failedNetworkRequest: Boolean = false,
-    val failedNetworkRequestMessage:String ="Network error, please try again later",
     val streamersListLoading: NetworkResponse<Boolean> = NetworkResponse.Loading,
     val showLoginModal: Boolean = false,
     val domainIsRegistered: Boolean = false,
@@ -78,6 +74,7 @@ data class HomeUIState(
     val modChannelShowBottomModal:Boolean = false,
 
     val homeRefreshing:Boolean = false,
+    val homeNetworkErrorMessage:String ="Disconnected from network"
 
 
 )
@@ -121,7 +118,8 @@ class HomeViewModel @Inject constructor(
                     if(!currentConnectionState && isConnectionLive){
                         //network reconnected
                         _uiState.value = _uiState.value.copy(
-                            networkConnectionState = true
+                            networkConnectionState = true,
+                            homeNetworkErrorMessage = "Disconnected from network"
                         )
                         refreshFromConnection()
 
@@ -130,7 +128,8 @@ class HomeViewModel @Inject constructor(
                         // network disconnection
                         Log.d("monitorForNetworkConnection","disconnected")
                         _uiState.value = _uiState.value.copy(
-                            networkConnectionState = false
+                            networkConnectionState = false,
+                            homeNetworkErrorMessage = "Disconnected from network"
                         )
                     }
                 }
@@ -421,11 +420,12 @@ class HomeViewModel @Inject constructor(
                     }
                     is NetworkResponse.NetworkFailure ->{
                         _uiState.value = _uiState.value.copy(
-                            failedNetworkRequest =true
+                            homeNetworkErrorMessage="Network error",
+                            networkConnectionState =false
                         )
                         delay(3000)
                         _uiState.value = _uiState.value.copy(
-                            failedNetworkRequest =false
+                            networkConnectionState =true
                         )
                     }
                 }
@@ -468,14 +468,9 @@ class HomeViewModel @Inject constructor(
                             is Response.Failure -> {
                                 Log.d("testingGetLiveStreams", "FAILED")
                                 _uiState.value = _uiState.value.copy(
-                                    failedNetworkRequest = true,
                                     homeRefreshing = false
                                 )
 
-                                delay(2000)
-                                _uiState.value = _uiState.value.copy(
-                                    failedNetworkRequest = false
-                                )
                             }
                         }
                     }
@@ -522,14 +517,7 @@ class HomeViewModel @Inject constructor(
                         // end
                         is Response.Failure -> {
                             _uiState.value = _uiState.value.copy(
-                                failedNetworkRequest = true,
                                 refreshing = false
-
-                            )
-
-                            delay(2000)
-                            _uiState.value = _uiState.value.copy(
-                                failedNetworkRequest = false
                             )
                         }
                     }

--- a/app/src/main/java/com/example/clicker/presentation/home/views/HomeComponents.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/views/HomeComponents.kt
@@ -88,8 +88,6 @@ object HomeComponents {
         urlList: List<StreamInfo>?,
         clientId: String,
         userId: String,
-        showFailedNetworkRequestMessage: Boolean,
-        failedNetworkRequestMessage:String,
         width:Int,
         height:Int,
         logout: () -> Unit,
@@ -124,8 +122,6 @@ object HomeComponents {
                     urlList =urlList,
                     clientId = clientId,
                     userId = userId,
-                    showFailedNetworkRequestMessage = showFailedNetworkRequestMessage,
-                    failedNetworkRequestMessage =failedNetworkRequestMessage,
                     height = height,
                     width = width,
                     logout = {

--- a/app/src/main/java/com/example/clicker/presentation/home/views/ScaffoldComponents.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/views/ScaffoldComponents.kt
@@ -124,8 +124,6 @@ object ScaffoldComponents {
         userId:String,
         height:Int,
         width:Int,
-        showFailedNetworkRequestMessage: Boolean,
-        failedNetworkRequestMessage:String,
         screenDensity:Float,
         homeRefreshing:Boolean,
         homeRefreshFunc:()->Unit,
@@ -160,14 +158,6 @@ object ScaffoldComponents {
             bottomBar = {Parts.CustomBottomBar(
                onNavigate= {id -> onNavigate(id)}
             )},
-
-            animatedErrorMessage ={modifier ->
-                Parts.AnimatedErrorMessage(
-                    modifier = modifier,
-                    showFailedNetworkRequestMessage =showFailedNetworkRequestMessage,
-                    errorMessage =failedNetworkRequestMessage
-                )
-            },
             pullToRefreshList ={contentPadding ->
                 PullToRefreshComponent(
                     padding = contentPadding,
@@ -218,7 +208,6 @@ object ScaffoldComponents {
          * @param bottomBar a composable function that represent the bottomBar content of the scaffold
          * @param liveChannelsLazyColumn a composable function that represent the main list of images and streamer information.
          * This will get covered by the scaffold
-         * @param animatedErrorMessage a animated composable function that will appear if there is a error message received from the network
          * */
         @Composable
         fun ScaffoldBuilder(
@@ -226,7 +215,6 @@ object ScaffoldComponents {
             drawerContent:@Composable () -> Unit,
             topBar:@Composable () -> Unit,
             bottomBar:@Composable () -> Unit,
-            animatedErrorMessage:@Composable (modifier: Modifier) -> Unit,
             pullToRefreshList:@Composable (contentPadding: PaddingValues) -> Unit,
         ){
 


### PR DESCRIPTION
# Related Issue
- #728


# Proposed changes
- replaced the animated error message with the network status UI composable
- This way, the error message always looks the same


# Additional context(optional)
- Now we have to move on to the 401 response implementations
