### PR TITLE
401 response to validateOAuthToken

### DIFF
--- a/app/src/main/java/com/example/clicker/data/workManager/OAuthTokeValidationWorker.kt
+++ b/app/src/main/java/com/example/clicker/data/workManager/OAuthTokeValidationWorker.kt
@@ -8,6 +8,7 @@ import androidx.work.Data
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.example.clicker.network.domain.TwitchAuthentication
+import com.example.clicker.util.NetworkAuthResponse
 import com.example.clicker.util.NetworkResponse
 import com.example.clicker.util.Response
 import com.google.gson.Gson
@@ -31,12 +32,12 @@ class OAuthTokeValidationWorker @AssistedInject constructor(
             .firstOrNull() // will catch either SUCCESS OF FAILURE
 
         return when (response) {
-            is NetworkResponse.Loading -> {
+            is NetworkAuthResponse.Loading -> {
                 Log.d("observeForeversWorker", "LOADING")
 
                 Result.success()
             }
-            is NetworkResponse.Success -> {
+            is NetworkAuthResponse.Success -> {
                 Log.d("observeForeversWorker", "SUCCESS")
                 Log.d("observeForeversWorker", response.data.toString())
 
@@ -47,7 +48,7 @@ class OAuthTokeValidationWorker @AssistedInject constructor(
 
                 Result.success(outputData)
             }
-            is NetworkResponse.Failure -> {
+            is NetworkAuthResponse.Failure -> {
                 Log.d("observeForeversWorker", "FAILED")
                 Result.failure()
             }

--- a/app/src/main/java/com/example/clicker/network/domain/TwitchAuthentication.kt
+++ b/app/src/main/java/com/example/clicker/network/domain/TwitchAuthentication.kt
@@ -1,6 +1,7 @@
 package com.example.clicker.network.domain
 
 import com.example.clicker.network.models.twitchAuthentication.ValidatedUser
+import com.example.clicker.util.NetworkAuthResponse
 import com.example.clicker.util.NetworkResponse
 import com.example.clicker.util.Response
 import kotlinx.coroutines.flow.Flow
@@ -18,10 +19,12 @@ interface TwitchAuthentication {
      * validateToken is a function that is called to validate [token] with the Twitch servers
      *
      * @param token a String representing a oAuth token
+     *
+     * @return a flow containing a [NetworkAuthResponse] object of type [ValidatedUser]
      * */
     suspend fun validateToken(
         url:String="https://id.twitch.tv/oauth2/validate",
-        token: String): Flow<NetworkResponse<ValidatedUser>>
+        token: String): Flow<NetworkAuthResponse<ValidatedUser>>
 
     /**
      * logout is a function that is called to end the user's logged in session

--- a/app/src/main/java/com/example/clicker/network/repository/TwitchAuthenticationImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchAuthenticationImpl.kt
@@ -7,8 +7,10 @@ import com.example.clicker.network.domain.TwitchAuthentication
 import com.example.clicker.network.interceptors.NoNetworkException
 import com.example.clicker.network.models.twitchAuthentication.ValidatedUser
 import com.example.clicker.network.repository.util.handleException
+import com.example.clicker.network.repository.util.handleNetworkAuthExceptions
 import com.example.clicker.network.repository.util.handleNoNetworkException
 import com.example.clicker.util.LogWrap
+import com.example.clicker.util.NetworkAuthResponse
 import com.example.clicker.util.NetworkResponse
 import com.example.clicker.util.Response
 import com.example.clicker.util.logCoroutineInfo
@@ -54,11 +56,11 @@ class TwitchAuthenticationImpl @Inject constructor(
     override suspend fun validateToken(
         url :String,
         token: String,
-    ): Flow<NetworkResponse<ValidatedUser>> = flow {
+    ): Flow<NetworkAuthResponse<ValidatedUser>> = flow {
         logCoroutineInfo("CoroutineDebugging", "Fetching from remote")
 
 
-        emit(NetworkResponse.Loading)
+        emit(NetworkAuthResponse.Loading)
         LogWrap.d(tag = "VALIDATINGTHETOKEN", message = "IT DO BE LogWrap LOADING")
         val response = twitchClient.validateToken(
             authorization = "OAuth $token"
@@ -67,14 +69,14 @@ class TwitchAuthenticationImpl @Inject constructor(
         Log.d("validateTokenImpl","code ->${response.code()} message -> ${response.message()}")
         if (response.isSuccessful) {
             LogWrap.d("VALIDATINGTHETOKEN", "LOGWRAP SUCCESS")
-            emit(NetworkResponse.Success(response.body()!!))
+            emit(NetworkAuthResponse.Success(response.body()!!))
         } else {
-            emit(NetworkResponse.Failure(Exception("Error! Please login again")))
+            emit(NetworkAuthResponse.Failure(Exception("Error! Please login again")))
             Log.d("VALIDATINGTHETOKEN", "ERROR")
         }
     }.catch { cause ->
 
-        handleNoNetworkException(cause)
+        handleNetworkAuthExceptions(cause)
 
     }
 }

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -386,15 +386,15 @@ class HomeViewModel @Inject constructor(
         oAuthenticationToken: String
     ) = viewModelScope.launch {
         withContext(ioDispatcher + CoroutineName("TokenValidator")) {
-            authentication.validateToken("https://id.twitch.tv/oauth2/validate",oAuthenticationToken)
+            authentication.validateToken("https://id.twitch.tv/oauth2/validate","oAuthenticationToken")
                 .collect { response ->
                     Log.d("monitorForNetworkConnection","validateOAuthTokenResponse ->${response}")
 
                 when (response) {
-                    is NetworkResponse.Loading -> {
+                    is NetworkAuthResponse.Loading -> {
                         // the loading state is to be left empty because its initial state is loading
                     }
-                    is NetworkResponse.Success -> {
+                    is NetworkAuthResponse.Success -> {
                         logCoroutineInfo("CoroutineDebugging", "GOT ITEMS from remote")
                         Log.d("VALIDATINGTOKEN", "TOKEN ---> SUCCESS.....")
 
@@ -408,7 +408,7 @@ class HomeViewModel @Inject constructor(
                         //todo:THIS SHOULD GET REMOVED. TOO MUCH IS GOING ON INSIDE OF THIS FUNCTION
                         tokenDataStore.setUsername(response.data.login)
                     }
-                    is NetworkResponse.Failure -> {
+                    is NetworkAuthResponse.Failure -> {
                         Log.d("VALIDATINGTOKEN", "TOKEN ---> FAILED.....")
 
                         _uiState.value = _uiState.value.copy(
@@ -418,7 +418,7 @@ class HomeViewModel @Inject constructor(
                             showLoginModal = true
                         )
                     }
-                    is NetworkResponse.NetworkFailure ->{
+                    is NetworkAuthResponse.NetworkFailure ->{
                         _uiState.value = _uiState.value.copy(
                             homeNetworkErrorMessage="Network error",
                             networkConnectionState =false
@@ -426,6 +426,11 @@ class HomeViewModel @Inject constructor(
                         delay(3000)
                         _uiState.value = _uiState.value.copy(
                             networkConnectionState =true
+                        )
+                    }
+                    is NetworkAuthResponse.Auth401Failure ->{
+                        _uiState.value = _uiState.value.copy(
+                            showLoginModal = true
                         )
                     }
                 }


### PR DESCRIPTION
# Related Issue
- #730


# Proposed changes
- implementing the 401 response to validateOAuthToken()
- this was done by changing the `NetworkResponse` to `NetworkAuthResponse`


# Additional context(optional)
- Now we can implement the generic Failure response
