### PR TITLE
changing the text for handling generic home errro

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -413,9 +413,9 @@ class HomeViewModel @Inject constructor(
 
                         _uiState.value = _uiState.value.copy(
                             streamersListLoading = NetworkResponse.Failure(
-                                Exception("Generic message")
+                                Exception("Error! Pull refresh")
                             ),
-                            showLoginModal = true
+
                         )
                     }
                     is NetworkAuthResponse.NetworkFailure ->{


### PR DESCRIPTION
# Related Issue
- #734


# Proposed changes
- just changing the text for NetworkAuthResponse.Failure  error response. 
- Also, removed the `showLoginModal = true` from the response


# Additional context(optional)
- any additional information necessary 
