### PR TITLE
handling 401 network response to getLiveStreams

### DIFF
--- a/app/src/main/java/com/example/clicker/network/domain/TwitchRepo.kt
+++ b/app/src/main/java/com/example/clicker/network/domain/TwitchRepo.kt
@@ -25,7 +25,7 @@ interface TwitchRepo {
         authorizationToken: String,
         clientId: String,
         userId: String
-    ): Flow<Response<List<StreamInfo>>>
+    ): Flow<NetworkAuthResponse<List<StreamInfo>>>
 
     /**
      * - getModeratedChannels() Gets a list of channels that the specified user has moderator privileges in.

--- a/app/src/main/java/com/example/clicker/network/repository/TwitchRepoImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchRepoImpl.kt
@@ -39,8 +39,8 @@ class TwitchRepoImpl @Inject constructor(
         authorizationToken: String,
         clientId: String,
         userId: String
-    ): Flow<Response<List<StreamInfo>>> = flow {
-        emit(Response.Loading)
+    ): Flow<NetworkAuthResponse<List<StreamInfo>>> = flow {
+        emit(NetworkAuthResponse.Loading)
 
         val response = twitchClient.getFollowedStreams(
             authorization = "Bearer $authorizationToken",
@@ -53,12 +53,12 @@ class TwitchRepoImpl @Inject constructor(
         val exported = body.data.map { it.toStreamInfo() }
 
         if (response.isSuccessful) {
-            emit(Response.Success(exported))
+            emit(NetworkAuthResponse.Success(exported))
         } else {
-            emit(Response.Failure(Exception("Error!, code: {${response.code()}}")))
+            emit(NetworkAuthResponse.Failure(Exception("Error!, code: {${response.code()}}")))
         }
     }.catch { cause ->
-        handleException(cause)
+        handleNetworkAuthExceptions(cause)
     }
 
     override suspend fun getModeratedChannels(


### PR DESCRIPTION
# Related Issue
- #739

# Proposed changes
- adding the 401 response handling for the `getLiveStreams()` method
- Also, changed all the `Response` return types to `NetworkAuthResponse`


# Additional context(optional)
- any additional information neccessary 
