### PR TITLE
adding the logic to handle the failed network response

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/modChannels/ModChannelView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/ModChannelView.kt
@@ -78,7 +78,7 @@ fun ModChannelView(
             offlineModChannelList = homeViewModel.state.value.offlineModChannelList,
             liveModChannelList = homeViewModel.state.value.liveModChannelList,
             modChannelResponseState = homeViewModel.state.value.modChannelResponseState,
-            refreshing = homeViewModel.state.value.refreshing,
+            refreshing = homeViewModel.state.value.modRefreshing,
             refreshFunc = {homeViewModel.pullToRefreshModChannels()},
             showNetworkMessage = !homeViewModel.state.value.networkConnectionState
 


### PR DESCRIPTION
# Related Issue
- #744

# Proposed changes
- added the logic to handle the failed network response on the get moderated channels.
- also, I changed the UI state variable name from `refreshing` to `modRefreshing`

# Additional context(optional)
- n/a
