### PR TITLE
adding the forward slash command for monitor

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -112,6 +112,8 @@ data class ForwardSlashCommands(
 val listOfCommands = listOf(
     ForwardSlashCommands(title="/ban [username] [reason] ", subtitle = "Permanently ban a user from chat",clickedValue="ban"),
     ForwardSlashCommands(title="/unban [username] ", subtitle = "Remove a timeout or a permanent ban on a user",clickedValue="unban"),
+    ForwardSlashCommands(title="/monitor [username] ", subtitle = "Start monitoring a user's messages (only visible to you)",clickedValue="monitor"),
+    ForwardSlashCommands(title="/unmonitor [username] ", subtitle = "Stop monitoring a user's messages",clickedValue="unmonitor")
 )
 
 @HiltViewModel
@@ -760,6 +762,15 @@ fun clearAllChatMessages(chatList: SnapshotStateList<TwitchUserData>){
             }
         }
     }
+    /**
+     * monitoringTokens() is a function meant to check the current user's chat messages for any /commands(/ban,/unban...)
+     *
+     *
+     * @param tokenCommand is a hot flow of [TextCommands] which only contains one instance of [TextCommands]. This instance
+     * is used to determine what the code should do
+     *
+     * @param chatMessage is a String representing what the user typed
+     * */
     private fun monitoringTokens(tokenCommand: StateFlow<TextCommands>,chatMessage:String){
         val isMod = _uiState.value.loggedInUserData?.mod ?: false
 
@@ -883,6 +894,33 @@ fun clearAllChatMessages(chatList: SnapshotStateList<TwitchUserData>){
                             .build()
                         listChats.add(message)
                     }
+                    is TextCommands.MONITOR ->{
+                       Log.d("MONITOR","Monitor --> ${tokenCommand.username}")
+                        monitoredUsers.add(tokenCommand.username)
+
+                        val message = TwitchUserDataObjectMother
+                            .addUserType(chatMessage)
+                            .addColor("#BF40BF")
+                            .addDisplayName(currentUsername)
+                            .addMod("mod")
+                            .addMessageType(MessageType.USER)
+                            .build()
+                        listChats.add(message)
+                    }
+                    is TextCommands.UnMONITOR ->{
+                        Log.d("MONITOR","UN-MONITOR --> ${tokenCommand.username}")
+                        monitoredUsers.remove(tokenCommand.username)
+
+                        val message = TwitchUserDataObjectMother
+                            .addUserType(chatMessage)
+                            .addColor("#BF40BF")
+                            .addDisplayName(currentUsername)
+                            .addMod("mod")
+                            .addMessageType(MessageType.USER)
+                            .build()
+                        listChats.add(message)
+                    }
+
                     //todo: should have a normal command that just sends information to the websocket
                     is TextCommands.INITIALVALUE ->{
                         Log.d("monitoringTokens", "INITIALVALUE")

--- a/app/src/main/java/com/example/clicker/presentation/stream/util/LexicalAnalysis.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/util/LexicalAnalysis.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
  * TokenType represents types that are used inside the lexical analysis of the chat messages
  * */
 enum class TokenType {
-    BAN, UNBAN,USERNAME,TEXT, UNRECOGNIZED
+    BAN, UNBAN,USERNAME,TEXT, UNRECOGNIZED,MONITOR,UNMONITOR
 }
 
 
@@ -20,6 +20,9 @@ data class Token(
      class UnBan(username:String):TextCommands(username)
      class UNRECOGNIZEDCOMMAND(command:String):TextCommands(command)
      class NORMALMESSAGE(message:String) : TextCommands(message)
+
+     class MONITOR(username: String):TextCommands(username)
+     class UnMONITOR(username: String):TextCommands(username)
      object NOUSERNAME : TextCommands()
      object INITIALVALUE : TextCommands()
 
@@ -32,6 +35,9 @@ class Scanner(private val source: String) {
         map["/ban"] = Token(TokenType.BAN,"/ban")
         map["/unban"] = Token(TokenType.UNBAN,"/unban")
         map["@username"] = Token(TokenType.USERNAME,"/username")
+
+        map["/monitor"] = Token(TokenType.MONITOR,"/monitor")
+        map["/unmonitor"] = Token(TokenType.UNMONITOR,"/unmonitor")
     }
     private val tokens = mutableListOf<Token>()
     val tokenList:List<Token> = tokens
@@ -169,6 +175,32 @@ class TokenCommand(){
                     _tokenCommand.tryEmit(TextCommands.NOUSERNAME)
                 }
             }
+            hasMonitorTokenType(tokenList) ->{
+                val username =tokenList
+                    .find{ it.tokenType == TokenType.USERNAME }?.lexeme
+                if(username != null){
+                    //todo: send unBan command
+
+                    _tokenCommand.tryEmit(TextCommands.MONITOR(username=username.replace("@", "")))
+                }
+                else{
+                    //todo: tell user that there is no username
+                    _tokenCommand.tryEmit(TextCommands.NOUSERNAME)
+                }
+            }
+            hasUnMonitorTokenType(tokenList) ->{
+                val username =tokenList
+                    .find{ it.tokenType == TokenType.USERNAME }?.lexeme
+                if(username != null){
+                    //todo: send unBan command
+
+                    _tokenCommand.tryEmit(TextCommands.UnMONITOR(username=username.replace("@", "")))
+                }
+                else{
+                    //todo: tell user that there is no username
+                    _tokenCommand.tryEmit(TextCommands.NOUSERNAME)
+                }
+            }
 
             else->{
                 val message = tokenList.map { it.lexeme }.joinToString(separator = " ")
@@ -179,6 +211,12 @@ class TokenCommand(){
 
     }
 
+    private fun hasMonitorTokenType(tokens: List<Token>): Boolean {
+        return tokens.any { it.tokenType == TokenType.MONITOR }
+    }
+    private fun hasUnMonitorTokenType(tokens: List<Token>): Boolean {
+        return tokens.any { it.tokenType == TokenType.UNMONITOR }
+    }
     private fun hasBanTokenType(tokens: List<Token>): Boolean {
         return tokens.any { it.tokenType == TokenType.BAN }
     }

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/BottomModal.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/BottomModal.kt
@@ -400,7 +400,9 @@ object BottomModal{
                         onClick = {
                             updateShouldMonitorUser()
                         }) {
-                        Text("Monitor",color = MaterialTheme.colorScheme.onSecondary)
+                        Text(
+                            if(shouldMonitorUser)"UnMonitor" else "Monitor",
+                            color = MaterialTheme.colorScheme.onSecondary)
                     }
                 }
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/MainChat.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/MainChat.kt
@@ -297,7 +297,7 @@ object MainChat{
                 reverseLayout = true
             ){
                 items(forwardSlashCommandList){command ->
-                    Column(modifier = Modifier
+                    Column(modifier = Modifier.fillMaxWidth()
                         .padding(horizontal = 10.dp, vertical = 5.dp)
                         .clickable {
                             clickedCommandAutoCompleteText(command.clickedValue)


### PR DESCRIPTION
# Related Issue
- #777


# Proposed changes
- adding the /monitor and /unmonitor commands 
- adding the `if(shouldMonitorUser)"UnMonitor" else "Monitor"` conditional check to the button text


# Additional context(optional)
- n/a
