### PR TITLE
separating methods into TwitchHomeClient

### DIFF
--- a/app/src/main/java/com/example/clicker/di/modules/SingletonModule.kt
+++ b/app/src/main/java/com/example/clicker/di/modules/SingletonModule.kt
@@ -6,6 +6,7 @@ import com.example.clicker.data.TokenDataStore
 import com.example.clicker.domain.TwitchDataStore
 import com.example.clicker.network.clients.TwitchAuthenticationClient
 import com.example.clicker.network.clients.TwitchClient
+import com.example.clicker.network.clients.TwitchHomeClient
 import com.example.clicker.network.domain.NetworkMonitorRepo
 import com.example.clicker.network.domain.TwitchAuthentication
 import com.example.clicker.network.domain.TwitchRepo
@@ -79,6 +80,22 @@ object SingletonModule {
             .addConverterFactory(GsonConverterFactory.create())
             .client(monitorClient)
             .build().create(TwitchAuthenticationClient::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun providesTwitchHomeClient(
+        liveNetworkMonitor: NetworkMonitor
+    ):TwitchHomeClient{
+        val monitorClient = OkHttpClient.Builder()
+            .addInterceptor(NetworkMonitorInterceptor(liveNetworkMonitor))
+            .addInterceptor(Authentication401Interceptor(ResponseChecker()))
+            .build()
+        return Retrofit.Builder()
+            .baseUrl("https://api.twitch.tv/helix/")
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(monitorClient)
+            .build().create(TwitchHomeClient::class.java)
     }
 
     @Singleton

--- a/app/src/main/java/com/example/clicker/network/clients/TwitchClient.kt
+++ b/app/src/main/java/com/example/clicker/network/clients/TwitchClient.kt
@@ -42,21 +42,7 @@ interface TwitchClient {
 
 
 
-    /**
-     * - getFollowedStreams represents a GET method. a function meant to get all of the user's live followed streams
-     *
-     * @param authorization a String used to represent the OAuth token that uniquely identifies this user's granted abilities
-     * @param clientId a String used to represent the clientId(unique identifier) of this application
-     * @param userId a String used to represent the OAuth token that uniquely identifies this user
-     *
-     * @return a [Response] object containing [FollowedLiveStreams]
-     * */
-    @GET("streams/followed")
-    suspend fun getFollowedStreams(
-        @Header("Authorization") authorization: String,
-        @Header("Client-Id") clientId: String,
-        @Query("user_id") userId: String
-    ): Response<FollowedLiveStreams>
+
 
     /**
      * - getChatSettings represents a GET method. A function meant to get the chat settings of the stream currently views
@@ -181,12 +167,7 @@ interface TwitchClient {
         @Body autoModSettings: IndividualAutoModSettings
     ):Response<AutoModSettings>
 
-    @GET("moderation/channels")
-    suspend fun getModeratedChannels(
-        @Header("Authorization") authorizationToken: String,
-        @Header("Client-Id") clientId: String,
-        @Query("user_id") userId: String
-    ):Response<GetModChannels>
+
 
 }
 data class GetModChannels(

--- a/app/src/main/java/com/example/clicker/network/clients/TwitchHomeClient.kt
+++ b/app/src/main/java/com/example/clicker/network/clients/TwitchHomeClient.kt
@@ -1,0 +1,61 @@
+package com.example.clicker.network.clients
+
+import com.example.clicker.network.models.twitchRepo.FollowedLiveStreams
+import com.google.gson.annotations.SerializedName
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Headers
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Query
+
+
+/**
+ * TwitchHomeClient is the interface that Retrofit will use and turn into a HTTP client. Specifically, this interface
+ * is meant to interact with the Twitch API for the home page
+ *
+ * @property getFollowedStreams a function meant to get all of the user's live followed streams
+ * @property getModeratedChannels a function meant to get all of the user's channels they are a moderator for (offline and online)
+ * */
+interface TwitchHomeClient {
+
+
+    /**
+     * - getFollowedStreams represents a GET method. a function meant to get all of the user's live followed streams
+     *
+     * @param authorization a String used to represent the OAuth token that uniquely identifies this user's granted abilities
+     * @param clientId a String used to represent the clientId(unique identifier) of this application
+     * @param userId a String used to represent the OAuth token that uniquely identifies this user
+     *
+     * @return a [Response] object containing [FollowedLiveStreams]
+     * */
+
+    @GET("streams/followed")
+    suspend fun getFollowedStreams(
+        @Header("Authorization") authorization: String,
+        @Header("Client-Id") clientId: String,
+        @Query("user_id") userId: String
+    ): Response<FollowedLiveStreams>
+
+    /**
+     * - getModeratedChannels represents a GET method. a function meant to get all of the user's channels they are a moderator for
+     *
+     * @param authorizationToken a String used to represent the OAuth token that uniquely identifies this user's granted abilities
+     * @param clientId a String used to represent the clientId(unique identifier) of this application
+     * @param userId a String used to represent the OAuth token that uniquely identifies this user
+     *
+     * @return a [Response] object containing [GetModChannels]
+     * */
+    @GET("moderation/channels")
+    suspend fun getModeratedChannels(
+        @Header("Authorization") authorizationToken: String,
+        @Header("Client-Id") clientId: String,
+        @Query("user_id") userId: String
+    ):Response<GetModChannels>
+}

--- a/app/src/main/java/com/example/clicker/network/domain/TwitchRepo.kt
+++ b/app/src/main/java/com/example/clicker/network/domain/TwitchRepo.kt
@@ -40,5 +40,4 @@ interface TwitchRepo {
         userId: String
     ):Flow<NetworkAuthResponse<GetModChannels>>
 
-    fun logout(clientId: String, token: String): Flow<Response<String>>
 }

--- a/app/src/test/java/com/example/clicker/ExampleUnitTest.kt
+++ b/app/src/test/java/com/example/clicker/ExampleUnitTest.kt
@@ -3,7 +3,6 @@ package com.example.clicker
 import com.example.clicker.network.clients.TwitchClient
 import com.example.clicker.network.domain.TwitchRepo
 import com.example.clicker.network.models.twitchRepo.FollowedLiveStreams
-import com.example.clicker.network.repository.TwitchRepoImpl
 import com.example.clicker.util.Response
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest

--- a/app/src/test/java/com/example/clicker/network/repository/TwitchRepoImplTest.kt
+++ b/app/src/test/java/com/example/clicker/network/repository/TwitchRepoImplTest.kt
@@ -1,9 +1,10 @@
 package com.example.clicker.network.repository
 
 import android.util.Log
+import com.example.clicker.network.clients.TwitchAuthenticationClient
 import com.example.clicker.network.clients.TwitchClient
 import com.example.clicker.network.domain.TwitchRepo
-import com.example.clicker.network.repository.util.TwitchStreamClientBuilder
+
 import com.example.clicker.presentation.stream.util.Scanner
 import com.example.clicker.presentation.stream.util.Token
 import com.example.clicker.presentation.stream.util.TokenType
@@ -15,12 +16,21 @@ import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
 
 class TwitchRepoImplTest {
 
     private lateinit var underTest: TwitchRepo
     private lateinit var twitchClient: TwitchClient
     private lateinit var mockWebServer: MockWebServer
+
+    /**WHAT TO TEST*/
+    //1) success with interceptors
+    //2) network interceptor throws errors
+    //3) 401 interceptor throws error
+    //4) empty response body
+    //5) 500 response error
 
 //
     @Before
@@ -36,38 +46,21 @@ class TwitchRepoImplTest {
         mockWebServer.shutdown()
     }
 
-    @Test
-    fun getAllFollowedStreamsNoNetworkResponse() = runTest {
-//        twitchClient = TwitchStreamClientBuilder
-//            .addFailingNetworkInterceptor()
-//            .buildClientWithURL(mockWebServer.url("/").toString()
-//            )
-//        underTest = TwitchRepoImpl(twitchClient)
-//        val expectedResponse = Response.Failure(Exception("Network error, please try again later"))
-//
-//
-//        /**WHEN*/
-//        val actualResponse = underTest
-//            .getFollowedLiveStreams("","","")
-//            .last()
-//
-//
-//        /**THEN*/
-//        Assert.assertEquals(expectedResponse.toString(), actualResponse.toString())
-    }
 
     @Test
-    fun TestingTheLexicalAnanysis(){
-        val scanner = Scanner("/ban @ turkeymeant44 ")
-        scanner.scanTokens()
-        val tokenList =scanner.tokenList
-//        tokenCommand(tokenList)
-
-
-
-        Assert.assertEquals(tokenList.size,4)
-
+    fun `when validateToken() returns a successful response BETTER version`()= runTest{
+        // make the retrofit client
+        val retrofitClient = Retrofit.Builder()
+            .baseUrl(mockWebServer.url("/").toString())
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(TwitchClient::class.java)
+        underTest = TwitchRepoImpl(retrofitClient)
     }
+
+
+
+
 
 
 


### PR DESCRIPTION
# Related Issue
- #798


# Proposed changes
- Creating the TwitchHomeClient interface and moving the `getFollowedStreams()` and `getModeratedChannels()` into it
- Also, added documentation to TwitchHomeClient interface


# Additional context(optional)
- Now back to testing the `TwitchRepoImpl` class
