### PR TITLE
adding the NewUser response state

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/home/views/HomeComponents.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/views/HomeComponents.kt
@@ -42,6 +42,7 @@ import com.example.clicker.network.models.twitchRepo.StreamData
 import com.example.clicker.presentation.home.StreamInfo
 import com.example.clicker.presentation.home.disableClickAndRipple
 import com.example.clicker.presentation.stream.ClickedStreamInfo
+import com.example.clicker.util.NetworkNewUserResponse
 import com.example.clicker.util.NetworkResponse
 import com.example.clicker.util.Response
 
@@ -83,7 +84,7 @@ import com.example.clicker.util.Response
         onNavigate: (Int) -> Unit,
         updateStreamerName: (String, String, String, String) -> Unit,
         updateClickedStreamInfo:(ClickedStreamInfo)->Unit,
-        streamersListLoading: NetworkResponse<Boolean>,
+        streamersListLoading: NetworkNewUserResponse<Boolean>,
         urlList: List<StreamData>?,
         clientId: String,
         userId: String,

--- a/app/src/main/java/com/example/clicker/presentation/home/views/ScaffoldComponents.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/views/ScaffoldComponents.kt
@@ -98,6 +98,7 @@ import com.example.clicker.presentation.sharedViews.PullToRefreshComponent
 import com.example.clicker.presentation.sharedViews.ScaffoldBottomBarScope
 import com.example.clicker.presentation.sharedViews.ScaffoldTopBarScope
 import com.example.clicker.presentation.stream.ClickedStreamInfo
+import com.example.clicker.util.NetworkNewUserResponse
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -132,7 +133,7 @@ class MainScaffoldScope(){
         login: () -> Unit,
         userIsLoggedIn: Boolean,
         urlList: List<StreamData>?,
-        urlListLoading: NetworkResponse<Boolean>,
+        urlListLoading: NetworkNewUserResponse<Boolean>,
         onNavigate: (Int) -> Unit,
         updateStreamerName: (String, String, String, String) -> Unit,
         updateClickedStreamInfo:(ClickedStreamInfo)->Unit,
@@ -789,7 +790,7 @@ class LiveChannelsLazyColumnScope(){
     @Composable
     fun LiveChannelsLazyColumn(
         urlList: List<StreamData>?,
-        urlListLoading: NetworkResponse<Boolean>,
+        urlListLoading: NetworkNewUserResponse<Boolean>,
         contentPadding: PaddingValues,
         loadingIndicator:@Composable IndicatorScopes.() -> Unit,
         emptyList:@Composable LiveChannelsLazyColumnScope.() -> Unit,
@@ -809,14 +810,14 @@ class LiveChannelsLazyColumnScope(){
 
 
             when (urlListLoading) {
-                is NetworkResponse.Loading -> {
+                is NetworkNewUserResponse.Loading -> {
                     item {
                         with(indicatorScopes){
                             loadingIndicator()
                         }
                     }
                 }
-                is NetworkResponse.Success -> {
+                is NetworkNewUserResponse.Success -> {
                     if (urlList != null) {
 
                         if (urlList.isEmpty()) {
@@ -837,7 +838,7 @@ class LiveChannelsLazyColumnScope(){
                         // end of the lazy column
                     }
                 }
-                is NetworkResponse.Failure -> {
+                is NetworkNewUserResponse.Failure -> {
 
                     item {
 
@@ -847,7 +848,7 @@ class LiveChannelsLazyColumnScope(){
                         }
                     }
                 }
-                is NetworkResponse.NetworkFailure -> {
+                is NetworkNewUserResponse.NetworkFailure -> {
 
                     item{
                         with(lazyColumnScope){
@@ -855,6 +856,13 @@ class LiveChannelsLazyColumnScope(){
                         }
                     }
 
+                }
+                is NetworkNewUserResponse.NewUser ->{
+                    item{
+                        with(lazyColumnScope){
+                            gettingStreamError(urlListLoading.message)
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/java/com/example/clicker/util/Response.kt
+++ b/app/src/main/java/com/example/clicker/util/Response.kt
@@ -85,4 +85,42 @@ sealed class NetworkAuthResponse<out T> {
 }
 
 
+/**
+ * Represents a network response and its specific error
+ *
+ * This class represents the 5 possible states of network responses in this application.
+ * - [NetworkNewUserResponse.Loading]
+ * - [NetworkNewUserResponse.NewUser]
+ * - [NetworkNewUserResponse.Success]
+ * - [NetworkNewUserResponse.Failure]
+ * - [NetworkNewUserResponse.NetworkFailure]
+ *
+ * @param T the value returned from the network request
+ *
+ *
+ */
+sealed class NetworkNewUserResponse<out T> {
+
+    object Loading : NetworkNewUserResponse<Nothing>()
+
+
+
+    data class Success<out T>(
+        val data: T
+    ) : NetworkNewUserResponse<T>()
+
+    data class NewUser(
+        val message:String
+    ): NetworkNewUserResponse<Nothing>()
+
+
+    data class Failure(
+        val e: Exception
+    ) : NetworkNewUserResponse<Nothing>()
+
+    data class NetworkFailure(
+        val e: Exception
+    ) : NetworkNewUserResponse<Nothing>()
+}
+
 


### PR DESCRIPTION
# Related Issue
- #885 


# Proposed changes
- Adding a new  util response type class of `NetworkNewUserResponse` that is a sealed class that includes `NewUser`.
- converted the compose views to reflect this


# Additional context(optional)
- Now is time to unit test this state
