### PR TITLE
adding and testing parsing method for TwitchEventSubWebSocket

### DIFF
--- a/app/src/main/java/com/example/clicker/network/websockets/TwitchEventSubWebSocket.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/TwitchEventSubWebSocket.kt
@@ -23,7 +23,8 @@ class TwitchEventSubWebSocket @Inject constructor(): WebSocketListener() {
 
     override fun onMessage(webSocket: WebSocket, text: String) {
         super.onMessage(webSocket, text)
-        Log.d("TwitchEventSubWebSocket","onMessage() message ->$text")
+        val parsedSessionId = parseEventSubWelcomeMessage(text)
+        Log.d("TwitchEventSubWebSocket","onMessage() parsedSessionId ->$parsedSessionId")
 
     }
 
@@ -58,4 +59,14 @@ class TwitchEventSubWebSocket @Inject constructor(): WebSocketListener() {
     fun closeWebSocket(){
         webSocket?.close(1009,"Bye")
     }
+
+
+}
+
+fun parseEventSubWelcomeMessage(stringToParse:String):String?{
+    val pattern = "\"id\":([^,]+)".toRegex()
+    val messageId = pattern.find(stringToParse)?.groupValues?.get(1)
+    val parsedMessageId = messageId?.replace("\"","")
+    return parsedMessageId
+
 }

--- a/app/src/test/java/com/example/clicker/network/repository/websockets/TwitchEventSubWebSocketTest.kt
+++ b/app/src/test/java/com/example/clicker/network/repository/websockets/TwitchEventSubWebSocketTest.kt
@@ -1,5 +1,6 @@
 package com.example.clicker.network.repository.websockets
 
+import com.example.clicker.network.websockets.parseEventSubWelcomeMessage
 import org.junit.Assert
 import org.junit.Test
 
@@ -8,8 +9,15 @@ class TwitchEventSubWebSocketTest {
 
     @Test
     fun testing_webSocket_stuff(){
+        /**GIVEN*/
+        val expectedMessageId ="AgoQYw-xoivNRc-gGlydLD3vABIGY2VsbC1i"
+        val stringToParse="{\"metadata\":{\"message_id\":\"8bfad1fb-8af7-4e9c-a028-c15c05575a7c\",\"message_type\":\"session_welcome\",\"message_timestamp\":\"2024-04-05T22:16:46.828736991Z\"},\"payload\":{\"session\":{\"id\":\"AgoQYw-xoivNRc-gGlydLD3vABIGY2VsbC1i\",\"status\":\"connected\",\"connected_at\":\"2024-04-05T22:16:46.818068229Z\",\"keepalive_timeout_seconds\":10,\"reconnect_url\":null,\"recovery_url\":null}}}"
 
-        Assert.assertEquals(1, 1)
+        /**WHEN*/
+        val parsedMessageId = parseEventSubWelcomeMessage(stringToParse)
+
+        Assert.assertEquals(expectedMessageId, parsedMessageId)
 
     }
+
 }


### PR DESCRIPTION
# Related Issue
- #1015


# Proposed changes
- created and tested the `parseEventSubWelcomeMessage()` method for parsing out the session_id of the eventsub welcoming message

# Additional context(optional)
- n/a
