### PR TITLE
hooking up the UI for the automod message status

### DIFF
--- a/app/src/main/java/com/example/clicker/network/domain/TwitchEventSubscriptions.kt
+++ b/app/src/main/java/com/example/clicker/network/domain/TwitchEventSubscriptions.kt
@@ -18,5 +18,5 @@ interface TwitchEventSubscriptions {
         oAuthToken:String,
         clientId:String,
         manageAutoModMessageData: ManageAutoModMessage
-    ) : Flow<String>
+    ) : Flow<Response<Boolean>>
 }

--- a/app/src/main/java/com/example/clicker/network/repository/TwitchEventSub.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchEventSub.kt
@@ -56,10 +56,8 @@ class TwitchEventSub @Inject constructor(
         oAuthToken: String,
         clientId: String,
         manageAutoModMessageData: ManageAutoModMessage
-    ):Flow<String> = flow {
-        emit("LOADING")
-        Log.d("manageAutoModMessage","oAuthToken ->$oAuthToken")
-        Log.d("manageAutoModMessage","LOADING")
+    ):Flow<Response<Boolean>> = flow {
+        emit(Response.Loading)
         val response = twitchClient.manageAutoModMessage(
             authorizationToken = "Bearer $oAuthToken",
             clientId = clientId,
@@ -67,26 +65,17 @@ class TwitchEventSub @Inject constructor(
         )
 
         if (response.isSuccessful) {
-            Log.d("manageAutoModMessage","SUCCESS")
-            Log.d("manageAutoModMessage","code--> ${response.code()}")
-            Log.d("manageAutoModMessage","message--> ${response.message()}")
-            Log.d("manageAutoModMessage","body--> ${response.body()}")
-
-            emit("NetworkNewUserResponse.Success(body.data)")
+            emit(Response.Success(true))
         } else {
 
-            emit("FAILED")
-            Log.d("manageAutoModMessage","FAILED")
-            Log.d("manageAutoModMessage","code--> ${response.code()}")
-            Log.d("manageAutoModMessage","message--> ${response.message()}")
-            Log.d("manageAutoModMessage","body--> ${response.body()}")
+            emit(Response.Failure(Exception("Failed action")))
         }
 
     }.catch { cause ->
         Log.d("manageAutoModMessage","ERROR CAUGHT")
         Log.d("manageAutoModMessage","cause.message --> ${cause.message}")
         Log.d("manageAutoModMessage","cause --> ${cause}")
-        emit("catchError")
+        emit(Response.Failure(Exception("Error")))
 
     }
 

--- a/app/src/main/java/com/example/clicker/network/websockets/TwitchEventSubWebSocket.kt
+++ b/app/src/main/java/com/example/clicker/network/websockets/TwitchEventSubWebSocket.kt
@@ -192,5 +192,7 @@ data class AutoModQueueMessage(
     val category: String = "",
     val messageId:String,
     val userId:String,
+    var approved:Boolean? = null,
+    var swiped:Boolean = false,
 
 )

--- a/app/src/main/java/com/example/clicker/presentation/modView/views/ModViewDragSection.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modView/views/ModViewDragSection.kt
@@ -818,19 +818,18 @@ object ModViewDragSection {
         autoModMessage: AutoModQueueMessage,
         manageAutoModMessage:(String,String,String)-> Unit
     ){
-        var pending:Boolean? by remember{ mutableStateOf(null) }
+
         HorizontalDragDetectionBox(
             itemBeingDragged ={offset ->
                 AutoModItemRow(
                     autoModMessage.username,
                     autoModMessage.fullText,
                     offset = offset,
-                    pending =pending,
+                    approved =autoModMessage.approved,
                     messageCategory = autoModMessage.category
                 )
             },
             quarterSwipeRightAction = {
-                pending = false
                 manageAutoModMessage(
                     autoModMessage.messageId,
                     autoModMessage.userId,
@@ -839,7 +838,6 @@ object ModViewDragSection {
                 Log.d("AutoModQueueBoxDragDetectionBox","RIGHT")
             },
             quarterSwipeLeftAction = {
-                pending = true
                 Log.d("AutoModQueueBoxDragDetectionBox","LEFT")
                 manageAutoModMessage(
                     autoModMessage.messageId,
@@ -850,9 +848,10 @@ object ModViewDragSection {
             twoSwipeOnly = true,
             quarterSwipeLeftIconResource = painterResource(id =R.drawable.baseline_check_24),
             quarterSwipeRightIconResource = painterResource(id =R.drawable.baseline_close_24),
-            swipeEnabled = true,
+            swipeEnabled = !autoModMessage.swiped,
         )
     }
+
 
     /**
      * AutoModItemRow is the composable function that is used inside of [AutoModQueueBox] to represent the individual AutoModQue messages
@@ -868,8 +867,9 @@ object ModViewDragSection {
         message: String,
         offset: Float,
         messageCategory: String,
-        pending:Boolean?
+        approved:Boolean?,
     ){
+
         val annotatedMessageText = buildAnnotatedString {
             withStyle(style = SpanStyle(color = Color.White)) {
                 append("$username: ")
@@ -891,7 +891,7 @@ object ModViewDragSection {
 
             ){
                 AutoModItemRowTesting(messageCategory)
-                AutoModItemPendingText(pending)
+                AutoModItemPendingText(approved)
 
             }
             Text(annotatedMessageText)
@@ -902,8 +902,10 @@ object ModViewDragSection {
         }
     }
     @Composable
-    fun AutoModItemPendingText(pending:Boolean?){
-        when(pending){
+    fun AutoModItemPendingText(
+        approved:Boolean?,
+    ){
+        when(approved){
             null ->{
                 Text("Pending approval", fontSize = MaterialTheme.typography.headlineSmall.fontSize)
             }


### PR DESCRIPTION
# Related Issue
- ##1040


# Proposed changes
- changing return types to Response
- Hooking up the UI to work with the `approved` 


# Additional context(optional)
-  n/a
