### PR TITLE
adding the horizontal blocker modView

### DIFF
--- a/app/src/main/res/layout/fragment_stream.xml
+++ b/app/src/main/res/layout/fragment_stream.xml
@@ -89,6 +89,7 @@
 
                 <androidx.compose.ui.platform.ComposeView
                     android:id="@+id/nested_draggable_compose_view"
+                    android:screenOrientation="portrait"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
                     app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
# Related Issue
- #1068


# Proposed changes
- adding `android:screenOrientation="portrait"` to remain vertical


# Additional context(optional)
- n/a
