### PR TITLE
added the Error UI for slash commands

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/util/TokenMonitoring.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/util/TokenMonitoring.kt
@@ -73,12 +73,12 @@ class TokenMonitoring @Inject constructor(){
                         }
                     }else{
                         val message = TwitchUserDataObjectMother
-                            .addUserType("You are not a moderator in this chat")
+                            .addUserType("You are not a moderator in this chat. You do not have the proper permissions for this command")
                             .addColor("#BF40BF")
                             .addDisplayName("System message")
                             .addMod("mod")
                             .addSystemMessage("")
-                            .addMessageType(MessageType.ANNOUNCEMENT)
+                            .addMessageType(MessageType.ERROR)
                             .build()
                         addMessageToListChats(message)
 


### PR DESCRIPTION
# Related Issue
- #1175


# Proposed changes
- adding a few extra words for the chat error message
- changed the message type in the slash command token monitoring from `ANNOUNCEMENT` to `ERROR`


# Additional context(optional)
- Now I need to implement this for the timeout and ban errors
