### PR TITLE
removing the delay from the softkeyboard showing

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
@@ -221,7 +221,6 @@ fun ChatUI(
                         },
                         showKeyBoard = {
                             scope.launch {
-                                delay(100)
                                 emoteKeyBoardHeight.value = 0.dp
                             }
                         }


### PR DESCRIPTION
# Related Issue
- #1202


# Proposed changes
- removed `delay(100)` from the showkeyboard function


# Additional context(optional)
- n/a
