### PR TITLE
fixing global emote bug

### DIFF
--- a/app/src/main/java/com/example/clicker/network/repository/TwitchEmotImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchEmotImpl.kt
@@ -202,7 +202,7 @@ class TwitchEmoteImpl @Inject constructor(
             val innerInlineContentMap: MutableMap<String, InlineTextContent> = mutableMapOf()
 
             val data = response.body()?.data
-            inlineContentMap.forEach{
+            _emoteList.value.map.forEach{
                 innerInlineContentMap[it.key] = it.value
             }
 


### PR DESCRIPTION
# Related Issue
- #1217 


# Proposed changes
- fixing the global emote bug by changing `inlineContentMap` to `_emoteList.value.map`


# Additional context(optional)
- n/a
