### PR TITLE
fixing the hide keyboard button bug

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
@@ -43,7 +43,8 @@ import kotlinx.coroutines.launch
 fun HorizontalChat(
     streamViewModel: StreamViewModel,
     autoModViewModel:AutoModViewModel,
-    modViewViewModel:ModViewViewModel
+    modViewViewModel:ModViewViewModel,
+    hideSoftKeyboard:()->Unit,
 ){
     val twitchUserChat = streamViewModel.listChats.toList()
     val lazyColumnListState = rememberLazyListState()
@@ -228,7 +229,7 @@ fun HorizontalChat(
                 clickedCommandAutoCompleteText={clickedValue -> streamViewModel.clickedCommandAutoCompleteText(clickedValue)},
                 inlineContentMap = streamViewModel.inlineTextContentTest.value,
                 hideSoftKeyboard ={
-
+                    hideSoftKeyboard()
                 },
                 emoteBoardGlobalList = streamViewModel.globalEmoteUrlList.value,
                 updateTextWithEmote = {newValue -> streamViewModel.addEmoteToText(newValue)},

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamFragment.kt
@@ -384,9 +384,10 @@ fun setOrientation(
                     homeViewModel,
                     notificationAmount=modViewViewModel.uiState.value.autoModQuePedingMessages,
                     hideSoftKeyboard ={
+                        hideSoftKeyboard()
                         if(!orientationIsLandscape){
                             Log.d("BindingComposeView","clicked")
-                            hideSoftKeyboard()
+
 
 //                            val editStreamInfoUI:View =binding.root.findViewById(R.id.nested_draggable_compose_view)
 //                            /**THE ANIMATION*/

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -2,6 +2,7 @@ package com.example.clicker.presentation.stream
 
 import android.annotation.SuppressLint
 import android.content.res.Configuration
+import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -121,7 +122,10 @@ fun StreamView(
             HorizontalChat(
                 streamViewModel,
                 autoModViewModel,
-                modViewViewModel
+                modViewViewModel,
+                hideSoftKeyboard={
+                    hideSoftKeyboard()
+                }
             )
         }
         else -> {


### PR DESCRIPTION
# Related Issue
- #1228


# Proposed changes
- fixing horizontal emote hide keyboard bug. Just moved `hideSoftKeyboard()` outside of the conditional 


# Additional context(optional)
- n/a
