### PR TITLE
moving the loggout functionality to logoutViewModel

### DIFF
--- a/app/src/main/java/com/example/clicker/data/TokenDataStore.kt
+++ b/app/src/main/java/com/example/clicker/data/TokenDataStore.kt
@@ -27,11 +27,9 @@ class TokenDataStore @Inject constructor(
     private val oAuthTokenKey = stringPreferencesKey("oAuth_token")
     private val usernameKey = stringPreferencesKey("username_value")
 
-    private val oneClickActionsKey = booleanPreferencesKey("one_click_action")
 
-    init{
+    private val userLoggedOutKey = booleanPreferencesKey("user_logged_out")
 
-    }
 
     override suspend fun setOAuthToken(oAuthToken: String) {
         val another =context.dataStore.edit { tokens ->
@@ -59,6 +57,22 @@ class TokenDataStore @Inject constructor(
         val username: Flow<String> = context.dataStore.data
             .map { preferences ->
                 preferences[usernameKey] ?: ""
+            }
+        return username
+    }
+
+    override suspend fun setLoggedOutStatus(loggedOut: Boolean) {
+
+        context.dataStore.edit { tokens ->
+            tokens[userLoggedOutKey] = loggedOut
+        }
+    }
+
+    override fun getLoggedOutStatus(): Flow<Boolean> {
+
+        val username: Flow<Boolean> = context.dataStore.data
+            .map { preferences ->
+                preferences[userLoggedOutKey] ?: false
             }
         return username
     }

--- a/app/src/main/java/com/example/clicker/domain/TwitchDataStore.kt
+++ b/app/src/main/java/com/example/clicker/domain/TwitchDataStore.kt
@@ -12,5 +12,8 @@ interface TwitchDataStore {
 
     fun getUsername(): Flow<String>
 
+    suspend fun setLoggedOutStatus(loggedOut:Boolean)
+    fun getLoggedOutStatus(): Flow<Boolean>
+
 
 }

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeFragment.kt
@@ -29,6 +29,7 @@ import com.example.clicker.BuildConfig
 import com.example.clicker.R
 import com.example.clicker.databinding.FragmentHomeBinding
 import com.example.clicker.presentation.authentication.AuthenticationViewModel
+import com.example.clicker.presentation.logout.LogoutViewModel
 import com.example.clicker.presentation.modView.ModViewViewModel
 import com.example.clicker.presentation.stream.AutoModViewModel
 import com.example.clicker.presentation.stream.StreamViewModel
@@ -58,6 +59,7 @@ class HomeFragment : Fragment() {
     private val streamViewModel: StreamViewModel by activityViewModels()
     private val autoModViewModel: AutoModViewModel by activityViewModels()
     private val modViewViewModel: ModViewViewModel by activityViewModels()
+    private val logoutViewModel: LogoutViewModel by activityViewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -145,8 +147,8 @@ class HomeFragment : Fragment() {
                         createNewTwitchEventWebSocket ={modViewViewModel.createNewTwitchEventWebSocket()},
                         hapticFeedBackError = {
                             view.performHapticFeedback(HapticFeedbackConstants.REJECT)
-                        }
-
+                        },
+                        logoutViewModel=logoutViewModel
 
                     )
                 }

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.example.clicker.R
 import com.example.clicker.presentation.home.views.HomeViewImplementation
+import com.example.clicker.presentation.logout.LogoutViewModel
 
 
 import com.example.clicker.presentation.stream.AutoModViewModel
@@ -33,6 +35,7 @@ import com.example.clicker.presentation.stream.StreamViewModel
 fun ValidationView(
     homeViewModel: HomeViewModel,
     streamViewModel: StreamViewModel,
+    logoutViewModel: LogoutViewModel,
     loginWithTwitch: () -> Unit,
     onNavigate: (Int) -> Unit,
     addToLinks: () -> Unit,
@@ -51,7 +54,7 @@ fun ValidationView(
     val userId = homeViewModel.validatedUser.collectAsState().value?.userId
     val clientId = homeViewModel.validatedUser.collectAsState().value?.clientId
     val oAuthToken = homeViewModel.state.value.oAuthToken
-    val isUserLoggedIn = homeViewModel.state.value.userIsLoggedIn
+
 
 
 
@@ -96,10 +99,12 @@ fun ValidationView(
         height = homeViewModel.state.value.aspectHeight,
         width = homeViewModel.state.value.width,
         logout = {
-            homeViewModel.beginLogout(
+
+            logoutViewModel.logout(
                 clientId = clientId?:"",
                 oAuthToken = oAuthToken
             )
+            onNavigate(R.id.action_homeFragment_to_logoutFragment)
             homeViewModel.hideLogoutDialog()
 
         },

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -141,63 +141,6 @@ class HomeViewModel @Inject constructor(
     }
 
 
-    fun beginLogout(clientId: String,oAuthToken: String) = viewModelScope.launch {
-//
-        withContext(ioDispatcher + CoroutineName("BeginLogout")) {
-            authentication.logout(
-                clientId = clientId,
-                token = oAuthToken
-            )
-                .collect { response ->
-                    when (response) {
-                        is NetworkAuthResponse.Loading -> {
-                            _uiState.value = _uiState.value.copy(
-                                streamersListLoading = NetworkNewUserResponse.Loading,
-                                showFailedDialog = false
-                            )
-                            _modChannelUIState.value =_modChannelUIState.value.copy(
-                                modChannelResponseState = NetworkNewUserResponse.Loading,
-                            )
-                        }
-                        is NetworkAuthResponse.Success -> {
-                            _uiState.value = _uiState.value.copy(
-                                userIsLoggedIn = response,
-                                homeRefreshing = false,
-
-                            )
-                            _modChannelUIState.value =_modChannelUIState.value.copy(
-                                modChannelResponseState = NetworkNewUserResponse.Auth401Failure(
-                                    Exception("Success! Login with Twitch")
-                                ),
-                                modRefreshing = false,
-                            )
-                            _validatedUser.value = null
-                        }
-                        is NetworkAuthResponse.Failure -> {
-                            _uiState.value = _uiState.value.copy(
-                                userIsLoggedIn = response,
-                                showFailedDialog = true
-                                )
-                        }
-                        is NetworkAuthResponse.NetworkFailure->{
-                            _uiState.value = _uiState.value.copy(
-                                userIsLoggedIn = response,
-                                showFailedDialog = true
-                            )
-                        }
-                        is NetworkAuthResponse.Auth401Failure ->{
-                            _uiState.value = _uiState.value.copy(
-                                userIsLoggedIn = response,
-                                showFailedDialog = true
-                            )
-                        }
-
-
-                    }
-                }
-        }
-    }
-
 
 
     fun registerDomian(isRegistered: Boolean) {
@@ -444,7 +387,7 @@ class HomeViewModel @Inject constructor(
      * */
     fun determineUserType(): UserTypes = runBlocking(Dispatchers.IO) {
         val token = tokenDataStore.getOAuthToken().first()
-        val loggedOut = false
+        val loggedOut = tokenDataStore.getLoggedOutStatus().first()
         when {
             token.length < 2 -> UserTypes.NEW
             loggedOut -> UserTypes.LOGGEDOUT

--- a/app/src/main/java/com/example/clicker/presentation/home/views/HomeComponents.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/views/HomeComponents.kt
@@ -164,9 +164,8 @@ import com.example.clicker.util.Response
                         closeDialog = {hideLogoutDialog()},
                         logout={
                             //todo: this is where we are going to navigate to the logout UI
-                            onNavigate(R.id.action_homeFragment_to_logoutFragment)
 
-                          //  logout()
+                            logout()
                         },
                         currentUsername =currentUsername
                     )

--- a/app/src/main/java/com/example/clicker/presentation/logout/LogoutFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/logout/LogoutFragment.kt
@@ -35,16 +35,19 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
+import androidx.fragment.app.activityViewModels
 import com.example.clicker.R
 import com.example.clicker.databinding.FragmentLogoutBinding
 import com.example.clicker.databinding.FragmentNewUserBinding
 import com.example.clicker.presentation.logout.views.MainComponent
+import com.example.clicker.presentation.stream.StreamViewModel
 
 
 class LogoutFragment : Fragment() {
 
     private var _binding: FragmentLogoutBinding? = null
     private val binding get() = _binding!!
+    private val logoutViewModel: LogoutViewModel by activityViewModels()
 
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/clicker/presentation/logout/LogoutViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/logout/LogoutViewModel.kt
@@ -1,0 +1,62 @@
+package com.example.clicker.presentation.logout
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.clicker.domain.TwitchDataStore
+import com.example.clicker.network.domain.TwitchAuthentication
+import com.example.clicker.util.NetworkAuthResponse
+import com.example.clicker.util.NetworkNewUserResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@HiltViewModel
+class LogoutViewModel @Inject constructor(
+    private val authentication: TwitchAuthentication,
+    private val tokenDataStore: TwitchDataStore,
+): ViewModel() {
+
+
+
+    fun logout(clientId:String,oAuthToken:String)  = viewModelScope.launch{
+        //so I need to logout and on success I need to set the internal logout flag to true
+        Log.d("newlogoutFunction","LogoutViewModel.logout() called")
+        withContext(Dispatchers.IO) {
+            authentication.logout(
+                clientId = clientId,
+                token = oAuthToken
+            )
+                .collect { response ->
+                    when (response) {
+                        is NetworkAuthResponse.Loading -> {
+                            Log.d("newlogoutFunction","LOADING")
+
+                        }
+                        is NetworkAuthResponse.Success -> {
+                            tokenDataStore.setLoggedOutStatus(true)
+                            Log.d("newlogoutFunction","SUCCESS")
+                        }
+                        is NetworkAuthResponse.Failure -> {
+                            Log.d("newlogoutFunction","FAILED")
+
+                        }
+                        is NetworkAuthResponse.NetworkFailure->{
+                            Log.d("newlogoutFunction","NETWORK FAILURE")
+
+                        }
+                        is NetworkAuthResponse.Auth401Failure ->{
+                            Log.d("newlogoutFunction","401 AUTH FAILURE")
+
+                        }
+
+
+                    }
+                }
+        }
+    }
+
+}


### PR DESCRIPTION
# Related Issue
- #1257


# Proposed changes
- adding `setLoggedOutStatus()` and `getLoggedOutStatus()` to TokenDataStore
- moving logout functionality to `LogoutViewModel`


# Additional context(optional)
- n/a
