### PR TITLE
removing the domain verification if it less than android12

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/newUser/NewUserFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/newUser/NewUserFragment.kt
@@ -33,10 +33,17 @@ class NewUserFragment : Fragment() {
     private val logoutViewModel: LogoutViewModel by activityViewModels()
     // twitchIntent.setPackage("com.example.clicker")
 
-    @RequiresApi(Build.VERSION_CODES.S)
+
     override fun onResume() {
         super.onResume()
-        checkDomainVerification()
+
+        if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.S){
+
+            checkDomainVerification()
+        }else{
+            logoutViewModel.setShowLoginWithTwitchButton(true)
+        }
+
 
        // Log.d("NewUserFragment", "allowed -> $allowed")
     }


### PR DESCRIPTION
# Related Issue
- #1269


# Proposed changes
- adding conditional for Android versions less than 12, allowing them to skip the domain verification because they don't need it


# Additional context(optional)
- n/a
