### PR TITLE
removing the new user response type

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -354,17 +354,7 @@ class HomeViewModel @Inject constructor(
                 //need to call the validateToken
                 //this should emit a value to a HOT storedOAuthToken flow which then runs the validateOAuthToken
                 _oAuthToken.tryEmit(storedOAuthToken)
-            } else {
-                _uiState.value = _uiState.value.copy(
-                    streamersListLoading = NetworkNewUserResponse.NewUser(
-                        "New user! Login with Twitch"
-                    ),
-                )
-
-
-           }
-
-
+            }
         }
     }
     /**
@@ -466,9 +456,7 @@ class HomeViewModel @Inject constructor(
                             modRefreshing = false
                         )
                     }
-                    is NetworkNewUserResponse.NewUser ->{
 
-                    }
                 }
             }
         }
@@ -572,9 +560,7 @@ class HomeViewModel @Inject constructor(
                             )
 
                         }
-                        is NetworkNewUserResponse.NewUser ->{
 
-                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/clicker/presentation/home/views/ScaffoldComponents.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/views/ScaffoldComponents.kt
@@ -855,12 +855,7 @@ class LiveChannelsLazyColumnScope(){
                         }
 
                     }
-                    is NetworkNewUserResponse.NewUser ->{
-                        item{
 
-                            newUserAlert(message = followedStreamerList.message)
-                        }
-                    }
                     is NetworkNewUserResponse.Auth401Failure ->{
                         item{
                             newUserAlert(message = followedStreamerList.e.message ?:"Error! Re-login with Twitch")

--- a/app/src/main/java/com/example/clicker/presentation/logout/LogoutViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/logout/LogoutViewModel.kt
@@ -49,7 +49,7 @@ class LogoutViewModel @Inject constructor(
 
     fun setShowLogin(value:Boolean)=viewModelScope.launch{
         _showLoading.value = value
-        tokenDataStore.setLoggedOutLoading(value)
+       // tokenDataStore.setLoggedOutLoading(value)
     }
     fun setNavigateHome(value:Boolean)=viewModelScope.launch{
         _navigateHome.value = value
@@ -126,9 +126,6 @@ class LogoutViewModel @Inject constructor(
                    is NetworkNewUserResponse.Loading->{
                        Log.d("validateOAuthTokenCall","Loading")
                    }
-                   is NetworkNewUserResponse.NewUser->{
-                       Log.d("validateOAuthTokenCall","NewUser")
-                   }
                    is NetworkNewUserResponse.Success ->{
                        Log.d("validateOAuthTokenCall","Success")
                        //todo: set the logout and login idea: set up the homeViewModel.determineUserType()
@@ -154,6 +151,42 @@ class LogoutViewModel @Inject constructor(
            }
 
        }
+    }
+
+    fun validateTokenNewUser(oAuthToken:String){
+        viewModelScope.launch(Dispatchers.IO){
+            delay(1000)
+            authentication.validateToken(oAuthToken).collect{response ->
+                when (response) {
+                    is NetworkNewUserResponse.Loading->{
+                        Log.d("validateOAuthTokenCall","Loading")
+                    }
+
+                    is NetworkNewUserResponse.Success ->{
+                        Log.d("validateOAuthTokenCall","Success")
+                        //todo: set the logout and login idea: set up the homeViewModel.determineUserType()
+                        tokenDataStore.setOAuthToken(oAuthToken)
+                        tokenDataStore.setLoggedOutStatus("FALSE")
+                        setShowLogin(false)
+                        setNavigateHome(true)
+                    }
+                    is NetworkNewUserResponse.Failure ->{
+                        Log.d("validateOAuthTokenCall","Failure")
+                        setShowLogin(false)
+                    }
+                    is NetworkNewUserResponse.NetworkFailure->{
+                        Log.d("validateOAuthTokenCall","NetworkFailure")
+                        setShowLogin(false)
+                    }
+                    is NetworkNewUserResponse.Auth401Failure ->{
+                        Log.d("validateOAuthTokenCall","Auth401Failure")
+                        setShowLogin(false)
+                    }
+                }
+
+            }
+
+        }
     }
 
 

--- a/app/src/main/java/com/example/clicker/presentation/modChannels/views/MainComponents.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/views/MainComponents.kt
@@ -354,9 +354,6 @@ object ModChannelComponents{
                             showLoginModal()
 
                         }
-                        is NetworkNewUserResponse.NewUser->{
-
-                        }
 
                     }
                 }

--- a/app/src/main/java/com/example/clicker/presentation/newUser/NewUserFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/newUser/NewUserFragment.kt
@@ -63,7 +63,7 @@ class NewUserFragment : Fragment() {
 
             val matchResult = accessTokenRegex.find(uri.toString())
             val oAuthToken = matchResult?.groupValues?.get(1)?:""
-//            logoutViewModel.validateOAuthToken(oAuthToken)
+            logoutViewModel.setShowLogin(true)
             Log.d("NewUserFragmentOAuthToken", "authCode -> $oAuthToken")
         }
     }

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/horizontalLongPress/LongPress.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/horizontalLongPress/LongPress.kt
@@ -220,13 +220,7 @@ fun TestingLazyColumnItem(
                 }
 
             }
-            is NetworkNewUserResponse.NewUser ->{
-                val message = "Error try again"
-                item {
-                    GettingStreamsError(message)
-                }
 
-            }
         }
 
 

--- a/app/src/main/java/com/example/clicker/util/Response.kt
+++ b/app/src/main/java/com/example/clicker/util/Response.kt
@@ -109,9 +109,7 @@ sealed class NetworkNewUserResponse<out T> {
         val data: T
     ) : NetworkNewUserResponse<T>()
 
-    data class NewUser(
-        val message:String
-    ): NetworkNewUserResponse<Nothing>()
+
 
 
     data class Failure(


### PR DESCRIPTION
# Related Issue
- #1278


# Proposed changes
- removing all of the `NetworkNewUserResponse.NewUser` instances
- adding the validateTokenNewUser() function


# Additional context(optional)
- n/a
