### PR TITLE
adding the clicked user modal for modView

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/modView/views/ModViewDragSection.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modView/views/ModViewDragSection.kt
@@ -174,6 +174,8 @@ import kotlin.math.roundToInt
 
         inlineContentMap: EmoteListMap,
         twitchUserChat: List<TwitchUserData>,
+        showBottomModal:()->Unit,
+        updateClickedUser: (String, String, Boolean, Boolean) -> Unit,
 
 
         ) {
@@ -212,7 +214,19 @@ import kotlin.math.roundToInt
                         boxTwoDragging =boxTwoDragging,
                         boxThreeDragging = boxThreeDragging,
                         inlineContentMap=inlineContentMap,
-                        twitchUserChat=twitchUserChat
+                        twitchUserChat=twitchUserChat,
+                        showBottomModal={
+                            showBottomModal()
+                            Log.d("BoxThreeChat","Clicked")
+                        },
+                        updateClickedUser = { username, userId, banned, isMod ->
+                            updateClickedUser(
+                                username,
+                                userId,
+                                banned,
+                                isMod
+                            )
+                        },
                     )
 
 
@@ -248,7 +262,16 @@ import kotlin.math.roundToInt
                         boxTwoDragging =boxTwoDragging,
                         boxThreeDragging = boxThreeDragging,
                         inlineContentMap=inlineContentMap,
-                        twitchUserChat=twitchUserChat
+                        twitchUserChat=twitchUserChat,
+                        showBottomModal={showBottomModal()},
+                        updateClickedUser = { username, userId, banned, isMod ->
+                            updateClickedUser(
+                                username,
+                                userId,
+                                banned,
+                                isMod
+                            )
+                        },
                     )
 
                 }
@@ -265,11 +288,7 @@ import kotlin.math.roundToInt
                 sectionBreakPoint =sectionBreakPoint,
                 animateToOnDragStop=animateToOnDragStop,
                 dragging = boxThreeDragging,
-                setDragging={
-
-                        newValue -> setBoxThreeDragging(newValue)
-                    Log.d("WHERETHEDOUBLEIS","DraggingBox")
-                            },
+                setDragging={ newValue -> setBoxThreeDragging(newValue) },
                 changeBackgroundColor={
                     if(boxThreeOffsetY>deleteOffsetY){
                         setBoxIndex("THREE",0)
@@ -278,18 +297,21 @@ import kotlin.math.roundToInt
                 content={
                     ChangingBoxTypes(
                         boxThreeIndex,
-                        setDraggingTrue = {
-                            setBoxThreeDragging(true)
-                            Log.d("WHERETHEDOUBLEIS","setDraggingTrue")
-                                          },
-                        setBoxDragging={
-                                value -> setBoxThreeDragging(value)
-                            Log.d("WHERETHEDOUBLEIS","ChangingBoxTypes")
-                                       },
+                        setDraggingTrue = { setBoxThreeDragging(true) },
+                        setBoxDragging={ value -> setBoxThreeDragging(value) },
                         boxTwoDragging =boxTwoDragging,
                         boxThreeDragging = boxThreeDragging,
                         inlineContentMap=inlineContentMap,
-                        twitchUserChat=twitchUserChat
+                        twitchUserChat=twitchUserChat,
+                        showBottomModal={ showBottomModal() },
+                        updateClickedUser = { username, userId, banned, isMod ->
+                            updateClickedUser(
+                                username,
+                                userId,
+                                banned,
+                                isMod
+                            )
+                        },
                     )
 
                 }
@@ -318,7 +340,9 @@ fun ChangingBoxTypes(
     boxThreeDragging:Boolean,
 
     twitchUserChat: List<TwitchUserData>,
-    inlineContentMap: EmoteListMap
+    inlineContentMap: EmoteListMap,
+    showBottomModal:()->Unit,
+    updateClickedUser: (String, String, Boolean, Boolean) -> Unit,
 ){
     when(boxIndex){
         0 ->{
@@ -339,8 +363,15 @@ fun ChangingBoxTypes(
             ){
                 SmallChat(
                     twitchUserChat=twitchUserChat,
-                    showBottomModal ={},
-                    updateClickedUser={val1,val2,val3,val4 ->},
+                    showBottomModal ={ showBottomModal() },
+                    updateClickedUser = { username, userId, banned, isMod ->
+                        updateClickedUser(
+                            username,
+                            userId,
+                            banned,
+                            isMod
+                        )
+                    },
                     showTimeoutDialog ={},
                     showBanDialog={},
                     doubleClickMessage={},

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamFragment.kt
@@ -54,6 +54,7 @@ import com.example.clicker.presentation.modView.ModViewDragStateViewModel
 import com.example.clicker.presentation.modView.ModViewViewModel
 import com.example.clicker.presentation.stream.views.horizontalLongPress.HorizontalLongPressView
 import com.example.clicker.presentation.stream.views.overlays.HorizontalOverlayView
+import com.example.clicker.presentation.stream.views.streamManager.ModViewComponent
 import com.example.clicker.presentation.stream.views.streamManager.ModViewScaffold
 import com.example.clicker.ui.theme.AppTheme
 
@@ -620,7 +621,7 @@ fun setOrientation(
             if(modViewDragStateViewModel.showModView.value){
                 AppTheme{
                     //todo: fill this in
-                    ModViewScaffold(
+                    ModViewComponent(
                         modViewDragStateViewModel=modViewDragStateViewModel,
                         closeModView ={
                             modViewDragStateViewModel.setShowModView(false)
@@ -629,7 +630,10 @@ fun setOrientation(
 //                            streamManagerUI.translationY = height
                         },
                         inlineContentMap=streamViewModel.inlineTextContentTest.value,
-                        twitchUserChat=streamViewModel.listChats.toList()
+                        twitchUserChat=streamViewModel.listChats.toList(),
+                        modViewViewModel=modViewViewModel,
+                        streamViewModel = streamViewModel
+
                     )
 
                 }

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -48,6 +48,9 @@ import com.example.clicker.presentation.stream.views.overlays.VerticalOverlayVie
 import com.example.clicker.util.Response
 import kotlinx.coroutines.launch
 
+
+
+
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun StreamView(
@@ -165,27 +168,16 @@ fun StreamView(
                             clickedUsername = streamViewModel.clickedUIState.value.clickedUsername,
                             bottomModalState = bottomModalState,
                             textFieldValue = streamViewModel.textFieldValue,
-                            closeBottomModal = {
-
-                            },
+                            closeBottomModal = {},
                             banned = streamViewModel.clickedUIState.value.clickedUsernameBanned,
                             unbanUser = {
                                 //  streamViewModel.unBanUser()
                             },
                             isMod = streamViewModel.state.value.loggedInUserData?.mod ?: false,
-                            openTimeoutDialog = {
-
-                                streamViewModel.openTimeoutDialog.value = true
-                            },
-
-                            openBanDialog = {
-                                streamViewModel.openBanDialog.value = true
-                                            },
+                            openTimeoutDialog = { streamViewModel.openTimeoutDialog.value = true },
+                            openBanDialog = { streamViewModel.openBanDialog.value = true },
                             shouldMonitorUser = streamViewModel.shouldMonitorUser.value,
-                            updateShouldMonitorUser = {
-
-                            },
-
+                            updateShouldMonitorUser = {},
                             )
                     }
                 ){


### PR DESCRIPTION
# Related Issue
- #1322 


# Proposed changes
- adding a [ModalBottomSheetLayout](https://foso.github.io/Jetpack-Compose-Playground/material/modalbottomsheetlayout/) to the chatMod view
- implementing the modals showing functionality to happen when the chat message is clicked


# Additional context(optional)
- n/a
