### PR TITLE
adding the shared Emotes to the channel UI

### DIFF
--- a/app/src/main/java/com/example/clicker/network/domain/TwitchEmoteRepo.kt
+++ b/app/src/main/java/com/example/clicker/network/domain/TwitchEmoteRepo.kt
@@ -27,6 +27,8 @@ import kotlinx.coroutines.flow.Flow
  * read more about the BetterTTV global emote, [HERE](https://betterttv.com/developers/api#global-emotes)
  * @property channelBetterTTVEmotes a [State] object containing a [IndivBetterTTVEmoteList] object that represents all the channel specific BetterTTV emotes.
  * You can read more about the BetterTTV channel emotes, [HERE](https://betterttv.com/developers/api#user)
+ * @property sharedBetterTTVEmotes a [State] object containing a [IndivBetterTTVEmoteList] object that represents all the shared BetterTTV emotes.
+ * You can read more about the BetterTTV shared emotes, [HERE](https://betterttv.com/developers/api#user)
  *
  * @property getGlobalEmotes()
  * @property getChannelEmotes()
@@ -42,6 +44,7 @@ interface TwitchEmoteRepo {
 
     val globalBetterTTVEmotes:State<IndivBetterTTVEmoteList>
     val channelBetterTTVEmotes:State<IndivBetterTTVEmoteList>
+    val sharedBetterTTVEmotes: State<IndivBetterTTVEmoteList>
 
     /**
      * getGlobalEmotes a function used to make a request to the Twitch servers to access the global emotes

--- a/app/src/main/java/com/example/clicker/network/repository/TwitchEmotImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchEmotImpl.kt
@@ -153,9 +153,13 @@ class TwitchEmoteImpl @Inject constructor(
     private val _channelBetterTTVEmotes = mutableStateOf<IndivBetterTTVEmoteList>(IndivBetterTTVEmoteList())
     override val channelBetterTTVEmotes:State<IndivBetterTTVEmoteList> = _channelBetterTTVEmotes
 
+    private val _sharedBetterTTVEmotes = mutableStateOf<IndivBetterTTVEmoteList>(IndivBetterTTVEmoteList())
+    override val sharedBetterTTVEmotes:State<IndivBetterTTVEmoteList> = _sharedBetterTTVEmotes
 
 
-      override fun getGlobalEmotes(
+
+
+    override fun getGlobalEmotes(
         oAuthToken: String,
         clientId: String,
     ): Flow<Response<Boolean>> = flow {
@@ -424,8 +428,8 @@ class TwitchEmoteImpl @Inject constructor(
             val channelEmotes = response.body()?.channelEmotes
             Log.d("getBetterTTVChannelEmotes", "sharedEmotes ->$sharedEmotes")
             Log.d("getBetterTTVChannelEmotes", "channelEmotes ->$channelEmotes")
-            response.body()?.channelEmotes?.also{listOfChannelEmotes ->
-                val parsedData =listOfChannelEmotes.map {channelEmote ->
+            channelEmotes?.also{listOfChannelEmotes ->
+                val parsedChannelEmotes =listOfChannelEmotes.map {channelEmote ->
                     IndivBetterTTVEmote(
                         id =channelEmote.id,
                         code=channelEmote.code,
@@ -435,9 +439,25 @@ class TwitchEmoteImpl @Inject constructor(
                         modifier = false
                     )
                 }
-                Log.d("getBetterTTVChannelEmotes", "parsedData ->$parsedData")
+                Log.d("getBetterTTVChannelEmotes", "parsedData ->$parsedChannelEmotes")
                 _channelBetterTTVEmotes.value = _channelBetterTTVEmotes.value.copy(
-                    list = parsedData
+                    list = parsedChannelEmotes
+                )
+            }
+
+            sharedEmotes?.also{listOfChannelEmotes ->
+                val parsedSharedEmotes =listOfChannelEmotes.map {channelEmote ->
+                    IndivBetterTTVEmote(
+                        id =channelEmote.id,
+                        code=channelEmote.code,
+                        imageType=channelEmote.imageType,
+                        animated = channelEmote.animated,
+                        userId = channelEmote.id,
+                        modifier = false
+                    )
+                }
+                _sharedBetterTTVEmotes.value = _sharedBetterTTVEmotes.value.copy(
+                    list = parsedSharedEmotes
                 )
             }
             Log.d("getBetterTTVChannelEmotes", "DONE")

--- a/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
@@ -242,7 +242,8 @@ fun HorizontalChat(
                 emoteBoardMostFrequentList= streamViewModel.mostFrequentEmoteListTesting.value,
                 updateMostFrequentEmoteList={value ->updateMostFrequentEmoteList(value)},
                 globalBetterTTVEmotes=streamViewModel.globalBetterTTVEmotes.value,
-                channelBetterTTVResponse = streamViewModel.channelBetterTTVEmote.value
+                channelBetterTTVResponse = streamViewModel.channelBetterTTVEmote.value,
+                sharedBetterTTVResponse= streamViewModel.sharedChannelBetterTTVEmote.value
             )
 
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -279,7 +279,8 @@ fun StreamView(
                             },
                             updateMostFrequentEmoteList = {value ->updateMostFrequentEmoteList(value)},
                             globalBetterTTVEmotes=streamViewModel.globalBetterTTVEmotes.value,
-                            channelBetterTTVResponse = streamViewModel.channelBetterTTVEmote.value
+                            channelBetterTTVResponse = streamViewModel.channelBetterTTVEmote.value,
+                            sharedBetterTTVResponse= streamViewModel.sharedChannelBetterTTVEmote.value
                         )
 
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -207,6 +207,7 @@ class StreamViewModel @Inject constructor(
 
     val globalBetterTTVEmotes=twitchEmoteImpl.globalBetterTTVEmotes
     val channelBetterTTVEmote = twitchEmoteImpl.channelBetterTTVEmotes
+    val sharedChannelBetterTTVEmote = twitchEmoteImpl.sharedBetterTTVEmotes
 
 
     /**

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/FullChatModView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/FullChatModView.kt
@@ -61,6 +61,7 @@ fun FullChatModView(
     setDragging: () -> Unit,
     globalBetterTTVEmotes: IndivBetterTTVEmoteList,
     channelBetterTTVResponse: IndivBetterTTVEmoteList,
+    sharedBetterTTVResponse: IndivBetterTTVEmoteList,
 ){
     val lazyColumnListState = rememberLazyListState()
     var autoscroll by remember { mutableStateOf(true) }
@@ -175,7 +176,8 @@ fun FullChatModView(
         emoteBoardMostFrequentList= emoteBoardMostFrequentList,
         updateMostFrequentEmoteList ={value ->updateMostFrequentEmoteList(value)},
         globalBetterTTVEmotes= globalBetterTTVEmotes,
-        channelBetterTTVResponse=channelBetterTTVResponse
+        channelBetterTTVResponse=channelBetterTTVResponse,
+        sharedBetterTTVResponse=sharedBetterTTVResponse
 
 
     )

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
@@ -176,6 +176,7 @@ fun ChatUI(
     emoteBoardMostFrequentList: EmoteNameUrlNumberList,
     globalBetterTTVEmotes: IndivBetterTTVEmoteList,
     channelBetterTTVResponse: IndivBetterTTVEmoteList,
+    sharedBetterTTVResponse: IndivBetterTTVEmoteList,
     updateMostFrequentEmoteList:(EmoteNameUrl)->Unit,
     updateTextWithEmote:(String) ->Unit,
     deleteEmote:()->Unit,
@@ -292,7 +293,8 @@ fun ChatUI(
         deleteEmote={deleteEmote()},
         updateMostFrequentEmoteList ={value ->updateMostFrequentEmoteList(value)},
         globalBetterTTVEmotes=globalBetterTTVEmotes,
-        channelBetterTTVResponse=channelBetterTTVResponse
+        channelBetterTTVResponse=channelBetterTTVResponse,
+        sharedBetterTTVResponse=sharedBetterTTVResponse
         )
 }
 
@@ -311,6 +313,7 @@ fun ChatUIBox(
     emoteBoardMostFrequentList: EmoteNameUrlNumberList,
     globalBetterTTVEmotes: IndivBetterTTVEmoteList,
     channelBetterTTVResponse: IndivBetterTTVEmoteList,
+    sharedBetterTTVResponse: IndivBetterTTVEmoteList,
     updateMostFrequentEmoteList:(EmoteNameUrl)->Unit,
     updateTextWithEmote:(String) ->Unit,
     closeEmoteBoard: () -> Unit,
@@ -351,7 +354,8 @@ fun ChatUIBox(
                             deleteEmote={deleteEmote()},
                             updateMostFrequentEmoteList={value ->updateMostFrequentEmoteList(value)},
                             globalBetterTTVEmotes =globalBetterTTVEmotes,
-                            channelBetterTTVResponse=channelBetterTTVResponse
+                            channelBetterTTVResponse=channelBetterTTVResponse,
+                            sharedBetterTTVResponse=sharedBetterTTVResponse
                         )
 
                 }
@@ -397,6 +401,7 @@ fun EmoteBoard(
     updateMostFrequentEmoteList:(EmoteNameUrl)->Unit,
     globalBetterTTVEmotes: IndivBetterTTVEmoteList,
     channelBetterTTVResponse: IndivBetterTTVEmoteList,
+    sharedBetterTTVResponse: IndivBetterTTVEmoteList,
     updateTextWithEmote:(String) ->Unit,
     closeEmoteBoard: () -> Unit,
     deleteEmote:()->Unit
@@ -493,7 +498,8 @@ fun EmoteBoard(
                         BetterTTVEmoteBoard(
                             globalBetterTTVResponse = globalBetterTTVEmotes,
                          //   updateTextWithEmote={value ->updateTextWithEmote(value)},
-                            channelBetterTTVResponse = channelBetterTTVResponse
+                            channelBetterTTVResponse = channelBetterTTVResponse,
+                            sharedBetterTTVResponse=sharedBetterTTVResponse
                         )
                         EmoteBottomUI(
                             closeEmoteBoard={closeEmoteBoard()},
@@ -530,6 +536,8 @@ fun EmoteBoard(
 fun BetterTTVEmoteBoard(
     globalBetterTTVResponse: IndivBetterTTVEmoteList,
     channelBetterTTVResponse: IndivBetterTTVEmoteList,
+    sharedBetterTTVResponse: IndivBetterTTVEmoteList,
+
     //updateTextWithEmote: (String) -> Unit
 
 ){
@@ -581,7 +589,39 @@ fun BetterTTVEmoteBoard(
                     )
                 }
 
+        /*****************************START OF THE SHARED CHANNEL EMOTES*******************************/
+        header {
+            Column(modifier= Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 5.dp)
+            ) {
+                Spacer(modifier  = Modifier.padding(5.dp))
+                Text(
+                    "Shared Emotes",
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    fontSize = MaterialTheme.typography.headlineSmall.fontSize
+                ) // or any composable for your single row
+                Spacer(modifier  = Modifier.padding(2.dp))
+                Divider(
+                    thickness = 2.dp,
+                    color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.8f),
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier  = Modifier.padding(5.dp))
+            }
 
+        }
+
+        items(sharedBetterTTVResponse.list){
+            GifLoadingAnimation(
+                url ="https://cdn.betterttv.net/emote/${it.id}/1x",
+                contentDescription = "${it.code} emote",
+                emoteName =it.code,
+                updateTextWithEmote ={value ->
+                    //  updateTextWithEmote(value)
+                }
+            )
+        }
 
 
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/streamManager/ModView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/streamManager/ModView.kt
@@ -272,7 +272,8 @@ fun ModViewComponent(
                         emoteBoardMostFrequentList= streamViewModel.mostFrequentEmoteListTesting.value,
                         updateMostFrequentEmoteList={value ->updateMostFrequentEmoteList(value)},
                         globalBetterTTVEmotes=streamViewModel.globalBetterTTVEmotes.value,
-                        channelBetterTTVResponse = streamViewModel.channelBetterTTVEmote.value
+                        channelBetterTTVResponse = streamViewModel.channelBetterTTVEmote.value,
+                        sharedBetterTTVResponse= streamViewModel.sharedChannelBetterTTVEmote.value
                     )
                 }
 


### PR DESCRIPTION
# Related Issue
- #1413


# Proposed changes
- adding the sharedBetterTTVEmotes to `TwitchEmoteRepo` interface, plus documentation
- dding the sharedBetterTTVEmotes emotes to the UI


# Additional context(optional)
- n/a 
