### PR TITLE
adding the horizontal betterttv emotes

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/views/horizontalLongPress/LongPress.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/horizontalLongPress/LongPress.kt
@@ -133,6 +133,7 @@ fun HorizontalLongPressView(
                                         streamViewModel.state.value.clientId,
                                         broadcasterId,
                                     )
+                                    streamViewModel.getBetterTTVChannelEmotes(broadcasterId)
 
                                 },
                                 updateClickedStreamInfo ={value -> updateClickedStreamInfo(value)},


### PR DESCRIPTION
# Related Issue
- #1425


# Proposed changes
- added `streamViewModel.getBetterTTVChannelEmotes(broadcasterId)` to the LongPress navigation


# Additional context(optional)
- n/a
