### PR TITLE
fixing the update clicked user messages

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
@@ -119,6 +119,7 @@ fun ModViewComponentVersionThree(
         initialValue = ModalBottomSheetValue.Hidden,
         skipHalfExpanded = true
     )
+    val clickedUsernameChatsWithDateSent = streamViewModel.clickedUsernameChatsWithDateSent.toList()
     val chatSettingsModalState = androidx.compose.material.rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
         skipHalfExpanded = true
@@ -159,14 +160,12 @@ fun ModViewComponentVersionThree(
         }
     ) {
 
-
-
     ModalBottomSheetLayout(
         sheetBackgroundColor = MaterialTheme.colorScheme.primary,
         sheetState = clickedChatterModalState,
         sheetContent = {
             BottomModal.BottomModalBuilder(
-                clickedUsernameChats = streamViewModel.clickedUsernameChats,
+                clickedUsernameChats = streamViewModel.clickedUsernameChats.toList(),
                 clickedUsername = streamViewModel.clickedUIState.value.clickedUsername,
                 bottomModalState = clickedChatterModalState,
                 textFieldValue = streamViewModel.textFieldValue,
@@ -181,7 +180,7 @@ fun ModViewComponentVersionThree(
                 openBanDialog = { streamViewModel.openBanDialog.value = true },
                 shouldMonitorUser = streamViewModel.shouldMonitorUser.value,
                 updateShouldMonitorUser = {},
-                clickedUsernameChatsWithDate = streamViewModel.clickedUsernameChatsWithDateSent,
+                clickedUsernameChatsWithDate = clickedUsernameChatsWithDateSent,
             )
         }
     ) {

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -641,6 +641,7 @@ class StreamViewModel @Inject constructor(
         val messages = listChats.filter { it.displayName == clickedUsername }
             .map { "${it.dateSend} " +if (it.deleted)  it.userType!! + " (deleted by mod)" else it.userType!!   }
 
+        
         val clickedUserChats = listChats.filter { it.displayName == clickedUsername }
         val clickedUserMessages = clickedUserChats.map {
             ClickedUserNameChats(
@@ -851,10 +852,20 @@ class StreamViewModel @Inject constructor(
                 Log.d("twitchUserMessage", " messageType --> ${twitchUserMessage.messageType}")
                 Log.d("twitchUserMessage", " twitchUserMessage --> ${twitchUserMessage}")
                 Log.d("twitchUserMessage", "-----------------------------------------------------")
+                Log.d("twitchUserMessageTesting", "displayName ->${twitchUserMessage.displayName}")
+                Log.d("twitchUserMessageTesting", "clickedUsername ->${_clickedUIState.value.clickedUsername}")
+                Log.d("twitchUserMessageTesting", "equal ->${twitchUserMessage.displayName == _clickedUIState.value.clickedUsername}")
 
                 if (twitchUserMessage.displayName == _clickedUIState.value.clickedUsername) {
 
                     clickedUsernameChats.add(twitchUserMessage.userType!!)
+                    clickedUsernameChatsWithDateSent.add(
+                        ClickedUserNameChats(
+                            message =twitchUserMessage.userType?:"",
+                            dateSent = twitchUserMessage.dateSend
+                        )
+                    )
+
                 }
                 if(monitoredUsers.contains(twitchUserMessage.displayName)){
                     //twitchUserMessage.isMonitored = true


### PR DESCRIPTION
# Related Issue
- #1471


# Proposed changes
- fixing the clicked user messages not updating bug by adding the `clickedUsernameChatsWithDateSent.add()` method call when the sent username matches the clicked username 


# Additional context(optional)
- n/a
