### PR TITLE
adding the authentication error message to the warn command

### DIFF
--- a/app/src/main/java/com/example/clicker/network/repository/TwitchStreamImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchStreamImpl.kt
@@ -6,6 +6,7 @@ import com.example.clicker.network.clients.ChannelInformation
 import com.example.clicker.network.clients.TwitchClient
 import com.example.clicker.network.clients.WarnUserBody
 import com.example.clicker.network.domain.TwitchStream
+import com.example.clicker.network.interceptors.responseCodeInterceptors.Authentication401Exception
 import com.example.clicker.network.models.twitchStream.AutoModSettings
 import com.example.clicker.network.models.twitchStream.BanUserResponse
 import com.example.clicker.network.models.twitchStream.IndividualAutoModSettings
@@ -191,7 +192,13 @@ class TwitchStreamImpl @Inject constructor(
         Log.d("warnUserResponse","EXCEPTION")
         Log.d("warnUserResponse","message ->${cause.message}")
         Log.d("warnUserResponse","cause ->${cause.cause}")
-        emit(Response.Failure(Exception("Error caught")))
+        Log.d("warnUserResponse","cause ->${cause.javaClass}")
+        if(cause is Authentication401Exception){
+            emit(Response.Success(false))
+        }else{
+            emit(Response.Failure(Exception("Error caught")))
+        }
+
     }
 
     override suspend fun getAutoModSettings(

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -1245,12 +1245,21 @@ fun warnUser()=viewModelScope.launch(Dispatchers.IO){
             when(response){
                 is Response.Loading->{}
                 is Response.Success->{
-                    val successMessage = TwitchUserDataObjectMother
-                        .addMessageType(MessageType.ANNOUNCEMENT)
-                        .addUserType("${_clickedUIState.value.clickedUsername} has been warned")
-                        .addSystemMessage("${_clickedUIState.value.clickedUsername} has been warned")
-                        .build()
-                    listChats.add(successMessage)
+                    if(response.data){
+                        val successMessage = TwitchUserDataObjectMother
+                            .addMessageType(MessageType.ANNOUNCEMENT)
+                            .addUserType("${_clickedUIState.value.clickedUsername} has been warned")
+                            .addSystemMessage("${_clickedUIState.value.clickedUsername} has been warned")
+                            .build()
+                        listChats.add(successMessage)
+                    }else{
+                        val successMessage = TwitchUserDataObjectMother
+                            .addMessageType(MessageType.NOTICE)
+                            .addUserType("Warn command failed due to authentication error. Please login again to be issued a token with proper authentication ")
+                            .addSystemMessage("Warn command failed due to authentication error. Please login again to be issued a token with proper authentication ")
+                            .build()
+                        listChats.add(successMessage)
+                    }
 
                 }
                 is Response.Failure->{
@@ -1282,12 +1291,22 @@ fun warnUser()=viewModelScope.launch(Dispatchers.IO){
             when(response){
                 is Response.Loading->{}
                 is Response.Success->{
-                    val successMessage = TwitchUserDataObjectMother
-                        .addMessageType(MessageType.ANNOUNCEMENT)
-                        .addUserType("${username} has been warned")
-                        .addSystemMessage("${username} has been warned")
-                        .build()
-                    listChats.add(successMessage)
+                    if(response.data){
+                        val successMessage = TwitchUserDataObjectMother
+                            .addMessageType(MessageType.ANNOUNCEMENT)
+                            .addUserType("${username} has been warned")
+                            .addSystemMessage("${username} has been warned")
+                            .build()
+                        listChats.add(successMessage)
+                    }else{
+                        val successMessage = TwitchUserDataObjectMother
+                            .addMessageType(MessageType.NOTICE)
+                            .addUserType("Warn command failed due to authentication error. Please login again to be issued a token with proper authentication ")
+                            .addSystemMessage("Warn command failed due to authentication error. Please login again to be issued a token with proper authentication ")
+                            .build()
+                        listChats.add(successMessage)
+                    }
+
 
                 }
                 is Response.Failure->{


### PR DESCRIPTION
# Related Issue
- #1504


# Proposed changes
- adding the authentication error UI if the user makes a warn command but does not have the proper authentication


# Additional context(optional)
- n/a
