### PR TITLE
clearing the chatter list when horizonal navigating

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/views/horizontalLongPress/LongPress.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/horizontalLongPress/LongPress.kt
@@ -140,6 +140,8 @@ fun HorizontalLongPressView(
                                 updateStreamerName ={
                                         streamerName,clientId,broadcasterId,userId ->
                                     updateStreamerName(streamerName,clientId,broadcasterId,userId)
+                                    Log.d("horizontalNavigation","CLICKING")
+                                    streamViewModel.clearAllChatters()
 
                                 },
                                 clientId =clientId,


### PR DESCRIPTION
# Related Issue
- #1513


# Proposed changes
- adding `streamViewModel.clearAllChatters()` to clear out the old chatter list


# Additional context(optional)
- n/a
