### PR TITLE
making compose code repeatable and skippable

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
@@ -386,7 +386,8 @@ fun ModViewComponentVersionThree(
                     globalBetterTTVEmotes = streamViewModel.globalBetterTTVEmotes.value,
                     channelBetterTTVResponse = streamViewModel.channelBetterTTVEmote.value,
                     sharedBetterTTVResponse = streamViewModel.sharedChannelBetterTTVEmote.value,
-                    userIsSub = streamViewModel.state.value.loggedInUserData?.sub ?: false
+                    userIsSub = streamViewModel.state.value.loggedInUserData?.sub ?: false,
+                    forwardSlashes=streamViewModel.forwardSlashCommandImmutable.value
                 )
 
             },

--- a/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
@@ -269,7 +269,8 @@ fun HorizontalChat(
                 globalBetterTTVEmotes=streamViewModel.globalBetterTTVEmotes.value,
                 channelBetterTTVResponse = streamViewModel.channelBetterTTVEmote.value,
                 sharedBetterTTVResponse= streamViewModel.sharedChannelBetterTTVEmote.value,
-                userIsSub = streamViewModel.state.value.loggedInUserData?.sub ?: false
+                userIsSub = streamViewModel.state.value.loggedInUserData?.sub ?: false,
+                forwardSlashes = streamViewModel.forwardSlashCommandImmutable.value
             )
 
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -302,7 +302,8 @@ fun StreamView(
                             globalBetterTTVEmotes=streamViewModel.globalBetterTTVEmotes.value,
                             channelBetterTTVResponse = streamViewModel.channelBetterTTVEmote.value,
                             sharedBetterTTVResponse= streamViewModel.sharedChannelBetterTTVEmote.value,
-                            userIsSub = streamViewModel.state.value.loggedInUserData?.sub ?: false
+                            userIsSub = streamViewModel.state.value.loggedInUserData?.sub ?: false,
+                            forwardSlashes = streamViewModel.forwardSlashCommandImmutable.value
                         )
 
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -363,6 +363,7 @@ class StreamViewModel @Inject constructor(
      * */
     var filteredChatList:SnapshotStateList<String> = textParsing.filteredChatList
     val forwardSlashCommands = textParsing.forwardSlashCommands
+    val forwardSlashCommandImmutable = textParsing.forwardSlashCommandsState
 
     fun clearFilteredChatterList(){
         textParsing.clearFilteredChatterList()

--- a/app/src/main/java/com/example/clicker/presentation/stream/util/TextParsing.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/util/TextParsing.kt
@@ -2,9 +2,13 @@ package com.example.clicker.presentation.stream.util
 
 import android.util.Log
 import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.getTextBeforeSelection
@@ -17,6 +21,17 @@ data class ForwardSlashCommands(
     val title:String,
     val subtitle:String,
     val clickedValue:String,
+)
+
+/**
+ * ForwardSlashCommandsImmutableCollection is a Wrapper object created specifically to handle the problem of the Compose compiler
+ *  always marking the List as unstable.
+ *  - You can read more about this Wrapper solution, [HERE](https://developer.android.com/develop/ui/compose/performance/stability/fix#annotated-classes)
+ *
+ * */
+@Immutable
+data class ForwardSlashCommandsImmutableCollection(
+    val snacks: List<ForwardSlashCommands>
 )
 
 class TextParsing @Inject constructor() {
@@ -36,8 +51,38 @@ class TextParsing @Inject constructor() {
         )
     )
     var filteredChatList = mutableStateListOf<String>()
+
     private val _forwardSlashCommands = mutableStateListOf<ForwardSlashCommands>()
     val forwardSlashCommands = _forwardSlashCommands
+
+    /********** New forward slash command to make it immutable *************/
+    // Immutable state holder
+    private var _forwardSlashCommandsImmutableCollection by mutableStateOf(
+        ForwardSlashCommandsImmutableCollection(_forwardSlashCommands)
+    )
+
+    // Publicly exposed immutable state as State
+    val forwardSlashCommandsState: State<ForwardSlashCommandsImmutableCollection>
+        get() = mutableStateOf(_forwardSlashCommandsImmutableCollection)
+
+    // Update the collection whenever the mutable list changes
+    fun addForwardSlashCommand(command: ForwardSlashCommands) {
+        _forwardSlashCommands.add(command)
+        _forwardSlashCommandsImmutableCollection = ForwardSlashCommandsImmutableCollection(_forwardSlashCommands)
+    }
+    fun addAllForwardSlashCommand( commands:List<ForwardSlashCommands>){
+        _forwardSlashCommands.addAll(commands)
+        _forwardSlashCommandsImmutableCollection = ForwardSlashCommandsImmutableCollection(_forwardSlashCommands)
+
+    }
+
+    fun clearForwardSlashCommand() {
+        _forwardSlashCommands.clear()
+        _forwardSlashCommandsImmutableCollection = ForwardSlashCommandsImmutableCollection(listOf())
+    }
+
+
+    /**********New forward slash command to make it immutable  above*************/
 
     var parsingIndex:Int =0
     var startParsing:Boolean = false
@@ -147,17 +192,20 @@ class TextParsing @Inject constructor() {
                 Log.d("newParsingAgain",currentCharacter.toString())
                 slashCommandState = true
                 slashCommandIndex =textFieldValue.selection.start
-                _forwardSlashCommands.addAll(listOfCommands)
+                //_forwardSlashCommands.addAll(listOfCommands)
+                addAllForwardSlashCommand(listOfCommands)
             }
             if(currentCharacter.toString() == " "){
                 Log.d("newParsingAgainThing","currentCharacter.toString() == blank space")
-                _forwardSlashCommands.clear()
+               // _forwardSlashCommands.clear()
+                clearForwardSlashCommand()
                 slashCommandState = false
                 slashCommandIndex =0
             }
             if(currentCharacter.toString() == "" && slashCommandState){
                 Log.d("newParsingAgainThing","end currentCharacter and slashCommandState true")
-                _forwardSlashCommands.clear()
+               // _forwardSlashCommands.clear()
+                clearForwardSlashCommand()
                 slashCommandState = false
                 slashCommandIndex =0
             }
@@ -169,7 +217,8 @@ class TextParsing @Inject constructor() {
             if(currentCharacter.toString()==""){
                 Log.d("newParsingAgainThing","end currentCharacter")
                 endParsingNClearFilteredChatList()
-                _forwardSlashCommands.clear()
+               // _forwardSlashCommands.clear()
+                clearForwardSlashCommand()
                 slashCommandState = false
                 slashCommandIndex =0
             }
@@ -178,7 +227,8 @@ class TextParsing @Inject constructor() {
             if(textFieldValue.selection.start < parsingIndex && startParsing){
                 Log.d("newParsingAgainThing","textFieldValue.selection.start < parsingIndex && startParsing")
                 endParsingNClearFilteredChatList()
-                _forwardSlashCommands.clear()
+               // _forwardSlashCommands.clear()
+                clearForwardSlashCommand()
                 slashCommandState = false
 
             }
@@ -186,7 +236,8 @@ class TextParsing @Inject constructor() {
             if (currentCharacter.toString() == " " && startParsing){
                 Log.d("newParsingAgainThing","currentCharacter.toString() == blankspace && startParsing")
                 endParsingNClearFilteredChatList()
-                _forwardSlashCommands.clear()
+               // _forwardSlashCommands.clear()
+                clearForwardSlashCommand()
                 slashCommandState = false
 
             }
@@ -196,7 +247,8 @@ class TextParsing @Inject constructor() {
             }
 
             if(currentCharacter.toString() == "@"){
-                _forwardSlashCommands.clear()
+              //  _forwardSlashCommands.clear()
+                clearForwardSlashCommand()
                 showFilteredChatListNStartParsing(textFieldValue,allChatters)
             }
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/FullChatModView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/FullChatModView.kt
@@ -19,6 +19,7 @@ import com.example.clicker.network.repository.EmoteNameUrlList
 import com.example.clicker.network.repository.EmoteNameUrlNumberList
 import com.example.clicker.network.repository.IndivBetterTTVEmoteList
 import com.example.clicker.presentation.stream.util.ForwardSlashCommands
+import com.example.clicker.presentation.stream.util.ForwardSlashCommandsImmutableCollection
 import com.example.clicker.util.Response
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -62,7 +63,8 @@ fun FullChatModView(
     globalBetterTTVEmotes: IndivBetterTTVEmoteList,
     channelBetterTTVResponse: IndivBetterTTVEmoteList,
     sharedBetterTTVResponse: IndivBetterTTVEmoteList,
-    userIsSub:Boolean
+    userIsSub:Boolean,
+    forwardSlashes: ForwardSlashCommandsImmutableCollection
 ){
     val lazyColumnListState = rememberLazyListState()
     var autoscroll by remember { mutableStateOf(true) }
@@ -179,7 +181,8 @@ fun FullChatModView(
         globalBetterTTVEmotes= globalBetterTTVEmotes,
         channelBetterTTVResponse=channelBetterTTVResponse,
         sharedBetterTTVResponse=sharedBetterTTVResponse,
-        userIsSub = userIsSub
+        userIsSub = userIsSub,
+        forwardSlashes = forwardSlashes
 
 
     )

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
@@ -145,9 +145,13 @@ import coil.decode.ImageDecoderDecoder
 import com.example.clicker.network.clients.IndivBetterTTVEmote
 import com.example.clicker.network.repository.EmoteNameUrlNumberList
 import com.example.clicker.network.repository.IndivBetterTTVEmoteList
+import com.example.clicker.presentation.stream.util.ForwardSlashCommandsImmutableCollection
 import com.example.clicker.util.Response
 
-
+/**
+ * - restartable
+ * - NOT skippable
+ * */
 @Composable
 fun ChatUI(
     twitchUserChat: List<TwitchUserData>,
@@ -184,6 +188,7 @@ fun ChatUI(
     deleteEmote:()->Unit,
     showModView:()->Unit,
     userIsSub:Boolean,
+    forwardSlashes:ForwardSlashCommandsImmutableCollection
 ){
     val lazyColumnListState = rememberLazyListState()
     var autoscroll by remember { mutableStateOf(true) }
@@ -298,10 +303,15 @@ fun ChatUI(
         globalBetterTTVEmotes=globalBetterTTVEmotes,
         channelBetterTTVResponse=channelBetterTTVResponse,
         sharedBetterTTVResponse=sharedBetterTTVResponse,
-        userIsSub=userIsSub
+        userIsSub=userIsSub,
+        forwardSlashes=forwardSlashes
         )
 }
 
+/**
+ * - restartable
+ * - NOT skippable
+ * */
 @Composable
 fun ChatUIBox(
     determineScrollState: @Composable ImprovedChatUI.() -> Unit,
@@ -323,6 +333,7 @@ fun ChatUIBox(
     closeEmoteBoard: () -> Unit,
     deleteEmote:()->Unit,
     userIsSub:Boolean,
+    forwardSlashes: ForwardSlashCommandsImmutableCollection,
 ){
     val titleFontSize = MaterialTheme.typography.headlineMedium.fontSize
     val messageFontSize = MaterialTheme.typography.headlineSmall.fontSize
@@ -383,7 +394,8 @@ fun ChatUIBox(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 60.dp),
-                forwardSlashCommandList = forwardSlashCommands,
+                //forwardSlashCommandList = forwardSlashCommands,
+                forwardSlashes =forwardSlashes,
                 clickedCommandAutoCompleteText={clickedValue -> clickedCommandAutoCompleteText(clickedValue)}
             )
         }
@@ -397,6 +409,10 @@ fun LazyGridScope.header(
     item(span = { GridItemSpan(this.maxLineSpan) }, content = content)
 }
 
+/**
+ * - restartable
+ * - skippable
+ * */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun EmoteBoard(
@@ -566,6 +582,10 @@ fun EmoteBoard(
     }
 
 }
+/**
+ * - restartable
+ * - skippable
+ * */
 @Composable
 fun BetterTTVEmoteBoard(
     globalBetterTTVResponse: IndivBetterTTVEmoteList,
@@ -707,6 +727,10 @@ fun BetterTTVEmoteBoard(
 }
 
 
+/**
+ * - restartable
+ * - skippable
+ * */
 @Composable
 fun GifLoadingAnimation(
     url:String,
@@ -738,6 +762,11 @@ fun GifLoadingAnimation(
             }
     )
 }
+
+/**
+ * - restartable
+ * - skippable
+ * */
 @Composable
 fun EmoteBottomUI(
     closeEmoteBoard:()->Unit,
@@ -820,6 +849,10 @@ fun EmoteBottomUI(
     }
 }
 
+/**
+ * - restartable
+ * - skippable
+ * */
 @Composable
 fun BetterTTVEmoteBottomUI(
     closeEmoteBoard:()->Unit,
@@ -914,6 +947,10 @@ fun BetterTTVEmoteBottomUI(
 }
 
 
+/**
+ * - restartable
+ * - skippable
+ * */
 @OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun LazyGridEmotes(
@@ -1114,6 +1151,11 @@ fun LazyGridEmotes(
 
 @Stable
 class ImprovedChatUI(){
+
+    /**
+     * - restartable
+     * - skippable
+     * */
     @Composable
     fun DetermineScrollState(
         lazyColumnListState: LazyListState,
@@ -1151,6 +1193,9 @@ class ImprovedChatUI(){
     }
 
 
+    /**
+     * - restartable
+     * */
     @OptIn(ExperimentalFoundationApi::class)
     @Composable
     fun ChatUILazyColumn(
@@ -1236,6 +1281,10 @@ class ImprovedChatUI(){
         }
     }
 
+    /**
+     * - restartable
+     * - skippable
+     * */
     //so this does only recomp once
     @OptIn(ExperimentalMaterialApi::class)
     @Composable
@@ -1401,6 +1450,10 @@ class ImprovedChatUI(){
     }
 
 
+    /**
+     * - restartable
+     * - skippable
+     * */
     @Composable
     fun ScrollToBottom(
         scrollingPaused: Boolean,
@@ -1434,6 +1487,10 @@ class ImprovedChatUI(){
 }
 
 
+/**
+ * - restartable
+ * - skippable
+ * */
 /**
  * ClickableCard is the composable that implements the functionality that allows the user to click on a chat message
  * and have the bottom modal pop up
@@ -1512,6 +1569,10 @@ fun ClickableCard(
     }
 
 }
+/**
+ * - restartable
+ * - skippable
+ * */
 @Composable
 fun DoubleClickSeemsGoodIcon(){
 
@@ -1532,6 +1593,11 @@ fun DoubleClickSeemsGoodIcon(){
     }
 
 }
+
+/**
+ * - restartable
+ * - skippable
+ * */
 
 /**
  * HorizontalDragDetectionBox is a [Box] that will detect the user's drag movement and will move [itemBeingDragged] accordingly. Also, depending
@@ -1668,6 +1734,10 @@ fun HorizontalDragDetectionBox(
 }
 
 /**
+ * - restartable
+ * - skippable
+ * */
+/**
  * This is the entire chat textfield with the filtered row above it
  * */
 @Composable
@@ -1693,11 +1763,14 @@ fun EnterChatColumn(
     }
 }
 
-
+//fix this with wrapper
+/**
+ * - restartable
+ * */
 @Composable
 fun ForwardSlash(
     modifier:Modifier,
-    forwardSlashCommandList: List<ForwardSlashCommands>,
+    forwardSlashes: ForwardSlashCommandsImmutableCollection,
     clickedCommandAutoCompleteText:(String)->Unit,
 ){
 
@@ -1707,7 +1780,7 @@ fun ForwardSlash(
             .background(MaterialTheme.colorScheme.primary),
         reverseLayout = true
     ){
-        items(forwardSlashCommandList){command ->
+        items(forwardSlashes.snacks){command ->
             Column(modifier = Modifier
                 .padding(horizontal = 10.dp, vertical = 5.dp)
                 .clickable {
@@ -1736,6 +1809,10 @@ fun ForwardSlash(
 fun LazyListState.isScrolledToEnd() = layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1
 
 
+/**
+ * - restartable
+ * - skippable
+ * */
 /**
  * - Contains 0 extra parts
  * A [Button] meant to display a message surrounded by two icons.
@@ -1773,7 +1850,10 @@ fun DualIconsButton(
     }
 }
 
-
+/**
+ * - restartable
+ * - skippable
+ * */
 /**
  * This composable represents a clickable username shown to the user. When the [username] is clicked it will
  * automatically be added to the users text that they are typing
@@ -1807,6 +1887,10 @@ fun ClickedAutoText(
 
 }
 
+//- fix this
+/**
+ * - restartable
+ * */
 /**
  * A [LazyRow] used to represent all the usernames of every chatter in chat. This will be triggered to be shown
  * when a user enters the ***@*** character. This composable is also made up of the [TextChatParts.ClickedAutoText]
@@ -1835,6 +1919,10 @@ fun FilteredMentionLazyRow(
 }
 
 
+/**
+ * - restartable
+ * - skippable
+ * */
 /**
  * A Composable that will show an Icon based on the length of [textFieldValue]. If the length is greater than 0 then
  * the [ArrowForward] will be shown. If the length is less then or equal to 0 then the [MoreVert] will be shown
@@ -1876,7 +1964,10 @@ fun ShowIconBasedOnTextLength(
     }
 }
 
-
+/**
+ * - restartable
+ * - skippable
+ * */
 /**
  * A styled [TextField] to allow the user to enter chat messages
  * @param modifier determines how much of the screen it takes up. should be given a value of .weight(2f)
@@ -1995,7 +2086,10 @@ fun StylizedTextField(
 
 
 
-
+/**
+ * - restartable
+ * - skippable
+ * */
 /**
  * A composable meant to show a moderator Icon based on the status of [modStatus]
  *
@@ -2078,6 +2172,10 @@ fun ShowModStatus(
 }
 
 /**
+ * - restartable
+ * - skippable
+ * */
+/**
  * CheckIfUserDeleted is the composable that will be used to determine if there should be extra information shown
  * depending if the user's message has been deleted or not
  *
@@ -2094,6 +2192,11 @@ fun CheckIfUserDeleted(twitchUser: TwitchUserData){
         )
     }
 }
+
+/**
+ * - restartable
+ * - skippable
+ * */
 /**
  *
  * CheckIfUserIsBanned is the composable that will be used to determine if there should be extra information shown
@@ -2114,6 +2217,11 @@ fun CheckIfUserIsBanned(twitchUser: TwitchUserData){
     }
 }
 
+
+/**
+ * - restartable
+ * - skippable
+ * */
 /**
  *
  * TextWithChatBadges is really just a wrapper class around [ChatBadges] to allow us to use it a little more cleanly
@@ -2152,6 +2260,10 @@ fun TextWithChatBadges(
     } // end of the row
 }
 
+//fix this
+/**
+ * - restartable
+ * */
 /**
  *
  * ChatBadges is the composable that is responsible for showing the chat badges(mod or sub) beside the users username.

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/streamManager/ModView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/streamManager/ModView.kt
@@ -273,7 +273,8 @@ fun ModViewComponent(
                         globalBetterTTVEmotes=streamViewModel.globalBetterTTVEmotes.value,
                         channelBetterTTVResponse = streamViewModel.channelBetterTTVEmote.value,
                         sharedBetterTTVResponse= streamViewModel.sharedChannelBetterTTVEmote.value,
-                        userIsSub = streamViewModel.state.value.loggedInUserData?.sub ?: false
+                        userIsSub = streamViewModel.state.value.loggedInUserData?.sub ?: false,
+                        forwardSlashes = streamViewModel.forwardSlashCommandImmutable.value
                     )
                 }
 


### PR DESCRIPTION
# Related Issue
- #1524


# Proposed changes
- making the ForwardSlash composable function both repeatable and skippable to help with efficiency
- using the wrapper class to make a list stable 

# Additional context(optional)
- n/a
