### PR TITLE
making the ShowModStatus composable skipeable

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -123,6 +123,12 @@ fun StreamView(
             isMod
         )
     } }
+
+
+    val clearModViewNotifications:()->Unit = remember(modViewViewModel) { {
+        modViewViewModel.clearModViewNotifications()
+    } }
+
     val showWarnDialog = remember{ mutableStateOf(false) }
     var orientation by remember { mutableStateOf(Configuration.ORIENTATION_PORTRAIT) }
     val configuration = LocalConfiguration.current
@@ -288,7 +294,7 @@ fun StreamView(
                             deleteEmote={streamViewModel.deleteEmote()},
                             showModView={
                                 showModView()
-                                modViewViewModel.clearModViewNotifications()
+                                clearModViewNotifications()
                             },
                             updateMostFrequentEmoteList = {value ->updateMostFrequentEmoteList(value)},
                             globalBetterTTVEmotes=streamViewModel.globalBetterTTVEmotes.value,

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
@@ -231,7 +231,9 @@ fun ChatUI(
                         modStatus =isMod,
                         orientationIsVertical =orientationIsVertical,
                         notificationAmount=notificationAmount,
-                        showModView={showModView()}
+                        showModView={
+                            showModView()
+                        }
                     )
                 },
                 stylizedTextField ={boxModifier ->
@@ -2079,6 +2081,7 @@ fun ShowModStatus(
 ){
     val scope = rememberCoroutineScope()
     Log.d("isModCheck","isMod --> $modStatus")
+    Log.d("ShowModStatusRecomp","RECOMP")
 
     if(BuildConfig.BUILD_TYPE== "debug"){
         Box(){


### PR DESCRIPTION
# Related Issue
- #1546


# Proposed changes
- making the ShowModStatus composable skipeable by wrapping the modViewViewModel.clearModViewNotifications() 


# Additional context(optional)
- n/a
