### PR TITLE
making ShowIconBasedOnTextLength composable more efficient

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
@@ -208,6 +208,10 @@ fun ModViewComponentVersionThree(
         streamViewModel.changeActualTextFieldValue(text, textRange)
     } }
 
+    val sendMessageToWebSocket:(String) -> Unit = remember(streamViewModel) { { message ->
+        streamViewModel.sendMessage(message)
+    } }
+
     ModalBottomSheetLayout(
         sheetState = chatSettingsModalState,
         sheetContent ={
@@ -409,8 +413,8 @@ fun ModViewComponentVersionThree(
                     },
                     notificationAmount = 0,
                     textFieldValue = streamViewModel.textFieldValue,
-                    sendMessageToWebSocket = { string ->
-                        streamViewModel.sendMessage(string)
+                    sendMessageToWebSocket = { message ->
+                        sendMessageToWebSocket(message)
                     },
                     noChat = streamViewModel.advancedChatSettingsState.value.noChatMode,
                     deleteChatMessage = { messageId -> streamViewModel.deleteChatMessage(messageId) },

--- a/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
@@ -108,6 +108,10 @@ fun HorizontalChat(
         streamViewModel.changeActualTextFieldValue(text, textRange)
     } }
 
+    val sendMessageToWebSocket:(String) -> Unit = remember(streamViewModel) { { message ->
+        streamViewModel.sendMessage(message)
+    } }
+
 
     //todo: Also need to refactor the dialogs
 
@@ -246,8 +250,9 @@ fun HorizontalChat(
                 },
                 notificationAmount =0,
                 textFieldValue = streamViewModel.textFieldValue,
-                sendMessageToWebSocket = { string ->
-                    streamViewModel.sendMessage(string)
+                sendMessageToWebSocket = { message ->
+                    sendMessageToWebSocket(message)
+
                 },
                 noChat = streamViewModel.advancedChatSettingsState.value.noChatMode,
                 deleteChatMessage = {messageId ->streamViewModel.deleteChatMessage(messageId)},

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -139,6 +139,10 @@ fun StreamView(
         streamViewModel.changeActualTextFieldValue(text, textRange)
     } }
 
+    val sendMessageToWebSocket:(String) -> Unit = remember(streamViewModel) { { message ->
+        streamViewModel.sendMessage(message)
+    } }
+
     val showWarnDialog = remember{ mutableStateOf(false) }
     var orientation by remember { mutableStateOf(Configuration.ORIENTATION_PORTRAIT) }
     val configuration = LocalConfiguration.current
@@ -290,8 +294,8 @@ fun StreamView(
                             },
                             notificationAmount =modViewViewModel.uiState.value.modViewTotalNotifications,
                             textFieldValue = streamViewModel.textFieldValue,
-                            sendMessageToWebSocket = { string ->
-                                streamViewModel.sendMessage(string)
+                            sendMessageToWebSocket = { message ->
+                                sendMessageToWebSocket(message)
                             },
                             noChat = streamViewModel.advancedChatSettingsState.value.noChatMode,
                             deleteChatMessage={messageId ->streamViewModel.deleteChatMessage(messageId)},

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
@@ -273,8 +273,12 @@ fun ChatUI(
                 showIconBasedOnTextLength ={
                     ShowIconBasedOnTextLength(
                         textFieldValue =textFieldValue,
-                        chat = {item -> sendMessageToWebSocket(item)},
-                        showModal ={showModal()},
+                        chat = {item ->
+                            sendMessageToWebSocket(item)
+                               },
+                        showModal ={
+                            showModal()
+                                   },
                     )
                 },
             )
@@ -1929,6 +1933,7 @@ fun ShowIconBasedOnTextLength(
     chat: (String) -> Unit,
     showModal: () -> Unit,
 ){
+    Log.d("ShowIconBasedOnTextLengthRecomp","RECOMP")
 
     if (textFieldValue.value.text.isNotEmpty()) {
         androidx.compose.material.Icon(


### PR DESCRIPTION
# Related Issue
- #1550


# Proposed changes
- wrapping the `streamViewModel.sendMessage(message)` in a remember function to make it stable. 
- did this for vertical and horizontal chats


# Additional context(optional)
- n/a
