### PR TITLE
making the lists immutable in chatSettingsColumn

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
@@ -115,6 +115,8 @@ import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import com.example.clicker.presentation.modView.followerModeList
 import com.example.clicker.presentation.modView.slowModeList
+import com.example.clicker.presentation.modView.slowModeListImmutable
+import com.example.clicker.presentation.modView.followerModeListImmutable
 import com.example.clicker.util.Response
 import com.example.clicker.util.WebSocketResponse
 import com.example.clicker.presentation.stream.views.chat.HorizontalDragDetectionBox
@@ -221,10 +223,13 @@ fun ModViewComponentVersionThree(
                 changeNoChatMode = {newValue -> streamViewModel.setNoChatMode(newValue)},
 
                 chatSettingsEnabled = streamViewModel.state.value.loggedInUserData?.mod ?: false,
-                followerModeList= followerModeList,
+
+                followerModeListImmutable = followerModeListImmutable,
+                slowModeListImmutable=slowModeListImmutable,
+
                 selectedFollowersModeItem=modViewViewModel.uiState.value.selectedFollowerMode,
                 changeSelectedFollowersModeItem ={newValue -> modViewViewModel.changeSelectedFollowersModeItem(newValue)},
-                slowModeList= slowModeList,
+
                 selectedSlowModeItem=modViewViewModel.uiState.value.selectedSlowMode,
                 changeSelectedSlowModeItem ={newValue ->modViewViewModel.changeSelectedSlowModeItem(newValue)},
                 emoteOnly = modViewViewModel.uiState.value.emoteOnly,

--- a/app/src/main/java/com/example/clicker/presentation/modView/ModViewViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modView/ModViewViewModel.kt
@@ -105,10 +105,16 @@ ListTitleValue("1 day",1440),
     ListTitleValue("3 months",129600 )
 
 )
+@Immutable
+data class ImmutableModeList(
+    val modeList:List<ListTitleValue>
+)
+val followerModeListImmutable = ImmutableModeList(followerModeList)
+
+
 //1 week 10080
 //1 month 43200
 //3 months 129600
-
 val slowModeList =listOf(
     ListTitleValue("Off",null),
     ListTitleValue("3s",3),
@@ -118,6 +124,7 @@ val slowModeList =listOf(
     ListTitleValue("30s",30),
     ListTitleValue("60s",60 )
 )
+val slowModeListImmutable = ImmutableModeList(slowModeList)
 
 /**
  * AutoModMessageListImmutableCollection is a Wrapper object created specifically to handle the problem of the Compose compiler

--- a/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
@@ -27,7 +27,9 @@ import com.example.clicker.network.repository.EmoteNameUrl
 import com.example.clicker.network.repository.EmoteNameUrlList
 import com.example.clicker.presentation.modView.ModViewViewModel
 import com.example.clicker.presentation.modView.followerModeList
+import com.example.clicker.presentation.modView.followerModeListImmutable
 import com.example.clicker.presentation.modView.slowModeList
+import com.example.clicker.presentation.modView.slowModeListImmutable
 
 
 import com.example.clicker.presentation.stream.views.BottomModal
@@ -123,10 +125,14 @@ fun HorizontalChat(
                 changeAdvancedChatSettings = {newValue -> streamViewModel.updateAdvancedChatSettings(newValue)},
                 changeNoChatMode = {newValue -> streamViewModel.setNoChatMode(newValue)},
                 chatSettingsEnabled = modViewViewModel.uiState.value.enabledChatSettings,
-                followerModeList= followerModeList,
+
+                followerModeListImmutable = followerModeListImmutable,
+                slowModeListImmutable= slowModeListImmutable,
+
                 selectedFollowersModeItem=modViewViewModel.uiState.value.selectedFollowerMode,
-                changeSelectedFollowersModeItem ={newValue -> modViewViewModel.changeSelectedFollowersModeItem(newValue)},
-                slowModeList= slowModeList,
+                changeSelectedFollowersModeItem ={newValue ->
+                    modViewViewModel.changeSelectedFollowersModeItem(newValue)},
+
                 selectedSlowModeItem=modViewViewModel.uiState.value.selectedSlowMode,
                 changeSelectedSlowModeItem ={newValue ->modViewViewModel.changeSelectedSlowModeItem(newValue)},
                 emoteOnly = modViewViewModel.uiState.value.emoteOnly,

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -40,6 +40,8 @@ import com.example.clicker.presentation.home.HomeViewModel
 import com.example.clicker.presentation.modView.ModViewViewModel
 import com.example.clicker.presentation.modView.followerModeList
 import com.example.clicker.presentation.modView.slowModeList
+import com.example.clicker.presentation.modView.slowModeListImmutable
+import com.example.clicker.presentation.modView.followerModeListImmutable
 
 import com.example.clicker.presentation.stream.views.BottomModal.BottomModalBuilder
 import com.example.clicker.presentation.stream.views.chat.ChatSettingsColumn
@@ -172,20 +174,34 @@ fun StreamView(
                 sheetContent ={
                     ChatSettingsColumn(
                         advancedChatSettings = streamViewModel.advancedChatSettingsState.value,
-                        changeAdvancedChatSettings = {newValue -> streamViewModel.updateAdvancedChatSettings(newValue)},
-                        changeNoChatMode = {newValue -> streamViewModel.setNoChatMode(newValue)},
+                        changeAdvancedChatSettings = {newValue ->
+                            streamViewModel.updateAdvancedChatSettings(newValue)
+                                                     },
+                        changeNoChatMode = {newValue ->
+                            streamViewModel.setNoChatMode(newValue)
+                                           },
 
                         chatSettingsEnabled = streamViewModel.state.value.loggedInUserData?.mod ?: false,
-                        followerModeList= followerModeList,
+
+                        followerModeListImmutable = followerModeListImmutable,
+                        slowModeListImmutable=slowModeListImmutable,
+
                         selectedFollowersModeItem=modViewViewModel.uiState.value.selectedFollowerMode,
-                        changeSelectedFollowersModeItem ={newValue -> modViewViewModel.changeSelectedFollowersModeItem(newValue)},
-                        slowModeList= slowModeList,
+                        changeSelectedFollowersModeItem ={newValue ->
+                            modViewViewModel.changeSelectedFollowersModeItem(newValue)
+                                                         },
                         selectedSlowModeItem=modViewViewModel.uiState.value.selectedSlowMode,
-                        changeSelectedSlowModeItem ={newValue ->modViewViewModel.changeSelectedSlowModeItem(newValue)},
+                        changeSelectedSlowModeItem ={newValue ->
+                            modViewViewModel.changeSelectedSlowModeItem(newValue)
+                                                    },
                         emoteOnly = modViewViewModel.uiState.value.emoteOnly,
-                        setEmoteOnly = {newValue ->modViewViewModel.updateEmoteOnly(newValue)},
+                        setEmoteOnly = {newValue ->
+                            modViewViewModel.updateEmoteOnly(newValue)
+                                       },
                         subscriberOnly =modViewViewModel.uiState.value.subscriberOnly,
-                        setSubscriberOnly={newValue -> modViewViewModel.updateSubscriberOnly(newValue)},
+                        setSubscriberOnly={newValue ->
+                            modViewViewModel.updateSubscriberOnly(newValue)
+                                          },
                     )
                 }
             ) {

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ChatSettings.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ChatSettings.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.example.clicker.R
+import com.example.clicker.presentation.modView.ImmutableModeList
 import com.example.clicker.presentation.modView.ListTitleValue
 import com.example.clicker.presentation.stream.AdvancedChatSettings
 
@@ -78,11 +79,19 @@ fun ChatSettingsColumn(
      changeNoChatMode:(Boolean)->Unit,
 
 
-     followerModeList: List<ListTitleValue>,
+//     followerModeList: List<ListTitleValue>, //unstable
+     followerModeListImmutable: ImmutableModeList,
+
+//     slowModeList: List<ListTitleValue>, //unstable
+     slowModeListImmutable: ImmutableModeList,
+
+
+
+
+
      selectedFollowersModeItem: ListTitleValue,
      changeSelectedFollowersModeItem: (ListTitleValue) -> Unit,
 
-     slowModeList: List<ListTitleValue>,
      selectedSlowModeItem: ListTitleValue,
      changeSelectedSlowModeItem: (ListTitleValue) -> Unit,
      chatSettingsEnabled:Boolean,
@@ -126,6 +135,8 @@ fun ChatSettingsColumn(
             slowModeList=slowModeList,
             selectedSlowModeItem=selectedSlowModeItem,
             changeSelectedSlowModeItem ={newValue -> changeSelectedSlowModeItem(newValue)},
+            titleListImmutable = slowModeListImmutable
+
         )
 
         FollowersOnlyCheck(
@@ -133,7 +144,8 @@ fun ChatSettingsColumn(
             setExpanded ={newValue -> },
             followersOnlyList=followerModeList,
             selectedFollowersModeItem=selectedFollowersModeItem,
-            changeSelectedFollowersModeItem ={newValue -> changeSelectedFollowersModeItem(newValue)}
+            changeSelectedFollowersModeItem ={newValue -> changeSelectedFollowersModeItem(newValue)},
+            titleListImmutable = followerModeListImmutable
         )
         //todo: these are the modal items the pop up
 
@@ -291,6 +303,7 @@ fun SlowModeCheck(
     selectedSlowModeItem:ListTitleValue,
     changeSelectedSlowModeItem:(ListTitleValue)->Unit,
     slowModeList: List<ListTitleValue>,
+    titleListImmutable: ImmutableModeList,
 ){
 
     DropdownMenuItem(
@@ -313,7 +326,8 @@ fun SlowModeCheck(
                     titleList =slowModeList,
                     selectedItem = selectedSlowModeItem,
                     changeSelectedItem = {selectedValue ->changeSelectedSlowModeItem(selectedValue) },
-                    chatSettingsEnabled=chatSettingsEnabled
+                    chatSettingsEnabled=chatSettingsEnabled,
+                    titleListImmutable =titleListImmutable
                 )
             }
         }
@@ -325,6 +339,7 @@ fun FollowersOnlyCheck(
     setExpanded: (Boolean) -> Unit,
     chatSettingsEnabled:Boolean,
     followersOnlyList: List<ListTitleValue>,
+    titleListImmutable: ImmutableModeList,
     selectedFollowersModeItem:ListTitleValue,
     changeSelectedFollowersModeItem:(ListTitleValue)->Unit,
 ){
@@ -348,7 +363,8 @@ fun FollowersOnlyCheck(
                     titleList =followersOnlyList,
                     selectedItem = selectedFollowersModeItem,
                     changeSelectedItem = {selectedItem ->changeSelectedFollowersModeItem(selectedItem)},
-                    chatSettingsEnabled =chatSettingsEnabled
+                    chatSettingsEnabled =chatSettingsEnabled,
+                    titleListImmutable=titleListImmutable
                 )
             }
         }
@@ -358,6 +374,7 @@ fun FollowersOnlyCheck(
 @Composable
 fun EmbeddedDropDownMenu(
     titleList: List<ListTitleValue>, //this is the list shown to the user
+    titleListImmutable: ImmutableModeList,
     selectedItem:ListTitleValue,
     changeSelectedItem:(ListTitleValue)->Unit,
     chatSettingsEnabled:Boolean
@@ -404,7 +421,7 @@ fun EmbeddedDropDownMenu(
                     Color.DarkGray
                 )
         ){
-            for (item in titleList){
+            for (item in titleListImmutable.modeList){
                 TextMenuItem(
                     setExpanded={newValue -> expanded=newValue},
                     title = item.title,


### PR DESCRIPTION
# Related Issue
- #1552


# Proposed changes
- making the list variables for followerMode and slowMode immutable. Which means that they are now stable 


# Additional context(optional)
- n/a
