### PR TITLE
making the emoteboard close on fullchat

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/FullChatModView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/FullChatModView.kt
@@ -166,7 +166,12 @@ fun FullChatModView(
                 showIconBasedOnTextLength ={
                     ShowIconBasedOnTextLength(
                         textFieldValue =textFieldValue,
-                        chat = {item -> sendMessageToWebSocket(item)},
+                        chat = {item ->
+
+                            hideSoftKeyboard()
+                            emoteKeyBoardHeight.value = 0.dp// closes emote board
+                            sendMessageToWebSocket(item)
+                               },
                         showModal ={showModal()},
                     )
                 },


### PR DESCRIPTION
# Related Issue
- #1640


# Proposed changes
- adding:
```kotlin
 hideSoftKeyboard()
emoteKeyBoardHeight.value = 0.dp// closes emote board
```
 - makes sure that the text UI closes when the user sends a message


# Additional context(optional)
- n/a
