### PR TITLE
adding the example text that a user will edit

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/SliderUI.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/SliderUI.kt
@@ -6,12 +6,15 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -33,19 +36,30 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.example.clicker.R
 
 
 @Composable
 fun SliderAdvancedExample() {
 
 
+    ExampleText()
     Column(modifier = Modifier
         .fillMaxWidth()
         .padding(horizontal = 10.dp)) {
+
         ChatSlider(
             "Badge Size"
         )
@@ -93,3 +107,100 @@ fun ChatSlider(
 
 }
 
+@Composable
+fun ExampleText(){
+     val modBadge = "https://static-cdn.jtvnw.net/badges/v1/3267646d-33f0-4b17-b3df-f923a41db1d0/1"
+     val subBadge = "https://static-cdn.jtvnw.net/badges/v1/5d9f2208-5dd8-11e7-8513-2ff4adfae661/1"
+     val feelsGood = "https://static-cdn.jtvnw.net/emoticons/v2/64138/static/light/1.0"
+
+     val feelsGoodId ="SeemsGood"
+     val modId = "moderator"
+     val subId = "subscriber"
+
+    val inlineContent = mapOf(
+        Pair(
+
+            modId,
+            InlineTextContent(
+
+                Placeholder(
+                    width = 20.sp,
+                    height = 20.sp,
+                    placeholderVerticalAlign = PlaceholderVerticalAlign.Center
+                )
+            ) {
+                AsyncImage(
+                    model = modBadge,
+                    contentDescription = stringResource(R.string.moderator_badge_icon_description),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(2.dp)
+                )
+            }
+        ),
+        Pair(
+
+            subId,
+            InlineTextContent(
+
+                Placeholder(
+                    width = 20.sp,
+                    height = 20.sp,
+                    placeholderVerticalAlign = PlaceholderVerticalAlign.Center
+                )
+            ) {
+                AsyncImage(
+                    model = subBadge,
+                    contentDescription = stringResource(R.string.sub_badge_icon_description),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(2.dp)
+                )
+            }
+        ),
+        Pair(
+
+            feelsGoodId,
+            InlineTextContent(
+
+                Placeholder(
+                    width = 35.sp,
+                    height = 35.sp,
+                    placeholderVerticalAlign = PlaceholderVerticalAlign.Center
+                )
+            ) {
+                AsyncImage(
+                    model = feelsGood,
+                    contentDescription = stringResource(R.string.moderator_badge_icon_description),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(2.dp)
+                )
+            }
+        ),
+
+        )
+    val text = buildAnnotatedString {
+
+        appendInlineContent(modId, "[icon]")
+        appendInlineContent(subId, "[icon]")
+        withStyle(style = SpanStyle(color = Color.White)) {
+            append("TestUsername: ")
+        }
+        withStyle(style = SpanStyle(color = Color.White)) {
+            append("This test message is used to show how chat can look")
+            appendInlineContent(feelsGoodId, "[icon]")
+            appendInlineContent(feelsGoodId, "[icon]")
+            append(" and demonstrate the UI possibilities of editing the chat experience")
+        }
+
+        appendInlineContent(feelsGoodId, "[icon]")
+
+
+    }
+    Text(text = text,
+        inlineContent = inlineContent,
+        modifier = Modifier.fillMaxWidth().padding(5.dp),
+
+        )
+}


### PR DESCRIPTION
# Related Issue
-  #1649


# Proposed changes
- adding the UI example text that will demonstrate to users how the modified text will look


# Additional context(optional)
- n/a
