### PR TITLE
adding all of the chat editing values in a viewModel

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
@@ -142,9 +142,7 @@ fun ModViewComponentVersionThree(
     modVersionThreeViewModel:ModVersionThreeViewModel,// unstable
     chatSettingsViewModel: ChatSettingsViewModel,
 ){
-    val changeBadgeSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
-        chatSettingsViewModel.changeBadgeSize(newValue)
-    } }
+
 
     val clickedChatterModalState = androidx.compose.material.rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
@@ -256,6 +254,25 @@ fun ModViewComponentVersionThree(
         streamViewModel.updateTemporaryMostFrequentList(it)
     } }
 
+    /*******ALL FUNCTIONS RELATED TO CHAT SETTINGS SIZE***********/
+    val changeBadgeSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeBadgeSize(newValue)
+    } }
+    val changeEmoteSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeEmoteSize(newValue)
+    } }
+    val changeUsernameSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeUsernameSize(newValue)
+    } }
+    val changeMessageSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeMessageSize(newValue)
+    } }
+    val changeLineHeight:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeLineHeight(newValue)
+    } }
+    val changeCustomUsernameColor:(Boolean) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeCustomUsernameColor(newValue)
+    } }
 
 
     ModalBottomSheetLayout(
@@ -280,8 +297,19 @@ fun ModViewComponentVersionThree(
                 setEmoteOnly = {newValue ->modViewViewModel.updateEmoteOnly(newValue)},
                 subscriberOnly =modViewViewModel.uiState.value.subscriberOnly,
                 setSubscriberOnly={newValue -> modViewViewModel.updateSubscriberOnly(newValue)},
-                badgeSize = chatSettingsViewModel.badgeSize.value ,
-                changeBadgeSize = {newValue-> changeBadgeSize(newValue)}
+
+                badgeSize = chatSettingsViewModel.badgeSize.value,
+                changeBadgeSize = {newValue-> changeBadgeSize(newValue)},
+                emoteSize = chatSettingsViewModel.emoteSize.value,
+                changeEmoteSize={newValue -> changeEmoteSize(newValue)},
+                usernameSize = chatSettingsViewModel.usernameSize.value,
+                changeUsernameSize ={newValue ->changeUsernameSize(newValue)},
+                messageSize = chatSettingsViewModel.messageSize.value,
+                changeMessageSize={newValue ->changeMessageSize(newValue)},
+                lineHeight = chatSettingsViewModel.lineHeight.value,
+                changeLineHeight = {newValue -> changeLineHeight(newValue)},
+                customUsernameColor = chatSettingsViewModel.customUsernameColor.value,
+                changeCustomUsernameColor = {newValue -> changeCustomUsernameColor(newValue)}
             )
         }
     ) {

--- a/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
@@ -110,8 +110,24 @@ fun HorizontalChat(
         streamViewModel.updateMostFrequentEmoteList()
     } }
 
+    /*******ALL FUNCTIONS RELATED TO CHAT SETTINGS SIZE***********/
     val changeBadgeSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
         chatSettingsViewModel.changeBadgeSize(newValue)
+    } }
+    val changeEmoteSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeEmoteSize(newValue)
+    } }
+    val changeUsernameSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeUsernameSize(newValue)
+    } }
+    val changeMessageSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeMessageSize(newValue)
+    } }
+    val changeLineHeight:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeLineHeight(newValue)
+    } }
+    val changeCustomUsernameColor:(Boolean) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeCustomUsernameColor(newValue)
     } }
 
 
@@ -139,8 +155,19 @@ fun HorizontalChat(
                 setEmoteOnly = {newValue ->modViewViewModel.updateEmoteOnly(newValue)},
                 subscriberOnly =modViewViewModel.uiState.value.subscriberOnly,
                 setSubscriberOnly={newValue -> modViewViewModel.updateSubscriberOnly(newValue)},
-                badgeSize = chatSettingsViewModel.badgeSize.value ,
-                changeBadgeSize = {newValue-> changeBadgeSize(newValue)}
+
+                badgeSize = chatSettingsViewModel.badgeSize.value,
+                changeBadgeSize = {newValue-> changeBadgeSize(newValue)},
+                emoteSize = chatSettingsViewModel.emoteSize.value,
+                changeEmoteSize={newValue -> changeEmoteSize(newValue)},
+                usernameSize = chatSettingsViewModel.usernameSize.value,
+                changeUsernameSize ={newValue ->changeUsernameSize(newValue)},
+                messageSize = chatSettingsViewModel.messageSize.value,
+                changeMessageSize={newValue ->changeMessageSize(newValue)},
+                lineHeight = chatSettingsViewModel.lineHeight.value,
+                changeLineHeight = {newValue -> changeLineHeight(newValue)},
+                customUsernameColor = chatSettingsViewModel.customUsernameColor.value,
+                changeCustomUsernameColor = {newValue -> changeCustomUsernameColor(newValue)}
             )
         }
     ) {

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -212,15 +212,28 @@ fun StreamView(
     val getUnbanRequests:() -> Unit = remember(modViewViewModel) { {
         modViewViewModel.getUnbanRequests()
     } }
+    /*******ALL FUNCTIONS RELATED TO CHAT SETTINGS SIZE***********/
     val changeBadgeSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
         chatSettingsViewModel.changeBadgeSize(newValue)
     } }
-
-
-    var badgeSizeTesting by remember { mutableFloatStateOf(20f) }
-    val badgeSize:() -> Float = remember(chatSettingsViewModel) { {
-        chatSettingsViewModel.badgeSize.value
+    val changeEmoteSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeEmoteSize(newValue)
     } }
+    val changeUsernameSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeUsernameSize(newValue)
+    } }
+    val changeMessageSize:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeMessageSize(newValue)
+    } }
+    val changeLineHeight:(Float) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeLineHeight(newValue)
+    } }
+    val changeCustomUsernameColor:(Boolean) -> Unit = remember(chatSettingsViewModel) { {newValue ->
+        chatSettingsViewModel.changeCustomUsernameColor(newValue)
+    } }
+
+
+
 
 
 
@@ -270,8 +283,19 @@ fun StreamView(
                         setEmoteOnly = {newValue -> updateEmoteOnly(newValue) },
                         subscriberOnly =modViewViewModel.uiState.value.subscriberOnly,
                         setSubscriberOnly={newValue -> updateSubscriberOnly(newValue) },
+
                         badgeSize = chatSettingsViewModel.badgeSize.value,
-                        changeBadgeSize = {newValue-> changeBadgeSize(newValue)}
+                        changeBadgeSize = {newValue-> changeBadgeSize(newValue)},
+                        emoteSize = chatSettingsViewModel.emoteSize.value,
+                        changeEmoteSize={newValue -> changeEmoteSize(newValue)},
+                        usernameSize = chatSettingsViewModel.usernameSize.value,
+                        changeUsernameSize ={newValue ->changeUsernameSize(newValue)},
+                        messageSize = chatSettingsViewModel.messageSize.value,
+                        changeMessageSize={newValue ->changeMessageSize(newValue)},
+                        lineHeight = chatSettingsViewModel.lineHeight.value,
+                        changeLineHeight = {newValue -> changeLineHeight(newValue)},
+                        customUsernameColor = chatSettingsViewModel.customUsernameColor.value,
+                        changeCustomUsernameColor = {newValue -> changeCustomUsernameColor(newValue)}
                     )
                 }
             ) {

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/SliderUI.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/SliderUI.kt
@@ -340,13 +340,13 @@ fun ExampleText(
         }
         withStyle(style = SpanStyle(color = Color.White)) {
             withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.onPrimary, fontSize = messageSize.sp)) {
-                append("Test message used to show how chat can look")
+                append("Test used to show how chat can look")
             }
             appendInlineContent(feelsGoodId, "[icon]")
             appendInlineContent(feelsGoodId, "[icon]")
 
             withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.onPrimary, fontSize = messageSize.sp)) {
-                append(" and edit the chat experience")
+                append(" and edit the chat")
             }
 
         }

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/chatSettings/ChatSettings.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/chatSettings/ChatSettings.kt
@@ -97,16 +97,25 @@ fun ChatSettingsColumn(
      setSubscriberOnly:(Boolean) ->Unit,
 
      badgeSize:Float,
-     changeBadgeSize:(Float)->Unit
+     changeBadgeSize:(Float)->Unit,
+     emoteSize:Float,
+     changeEmoteSize:(Float)->Unit,
+     usernameSize:Float,
+     changeUsernameSize:(Float)->Unit,
+     messageSize:Float,
+     changeMessageSize:(Float)->Unit,
+     lineHeight: Float,
+     changeLineHeight:(Float)->Unit,
+     customUsernameColor: Boolean,
+     changeCustomUsernameColor: (Boolean)->Unit
 
 ){
     Log.d("ChatSettingsColumn","Recomping")
 
-    var emoteSize by remember { mutableFloatStateOf(35f) }
-    var usernameSize by remember { mutableFloatStateOf(15f) }
-    var messageSize by remember { mutableFloatStateOf(15f) }
-    var lineHeight by remember { mutableFloatStateOf((15f *1.6f)) }
-    var customUsernameColor by remember { mutableStateOf(true) }
+
+
+
+
 
 
 
@@ -170,7 +179,7 @@ fun ChatSettingsColumn(
             Column(){
                 ChatSettingsHeaderColumn("Chat Experience")
                 ExampleText(
-                    badgeSize = 35f,
+                    badgeSize = badgeSize,
                     usernameSize=usernameSize,
                     messageSize = messageSize,
                     emoteSize = emoteSize,
@@ -186,15 +195,15 @@ fun ChatSettingsColumn(
                 badgeSize=badgeSize,
                 changeBadgeSliderValue={newValue -> changeBadgeSize(newValue)},
                 usernameSize=usernameSize,
-                changeUsernameSize = {newValue -> usernameSize = newValue},
+                changeUsernameSize = {newValue -> changeUsernameSize(newValue)},
                 messageSize = messageSize,
-                changeMessageSize = {newValue ->messageSize = newValue},
+                changeMessageSize = {newValue ->changeMessageSize(newValue)},
                 emoteSize = emoteSize,
-                changeEmoteSize = {newValue -> emoteSize = newValue},
+                changeEmoteSize = {newValue -> changeEmoteSize(newValue)},
                 lineHeight =lineHeight,
-                changeLineHeight = {newValue -> lineHeight = newValue},
+                changeLineHeight = {newValue -> changeLineHeight(newValue)},
                 customUsernameColor =customUsernameColor,
-                changeCustomUsernameColor ={newValue -> customUsernameColor = newValue}
+                changeCustomUsernameColor ={newValue -> changeCustomUsernameColor(newValue)}
             )
         }
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/chatSettings/ChatSettingsViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/chatSettings/ChatSettingsViewModel.kt
@@ -2,7 +2,11 @@ package com.example.clicker.presentation.stream.views.chat.chatSettings
 
 import android.util.Log
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,9 +22,44 @@ class ChatSettingsViewModel @Inject constructor(): ViewModel() {
     private val _badgeSize = mutableStateOf(20f)  // Initial value
     val badgeSize: State<Float> = _badgeSize
 
+
+    private val _emoteSize = mutableStateOf(35f)  // Initial value
+    val emoteSize: State<Float> = _emoteSize
+
+
+    private val _usernameSize = mutableStateOf(15f)  // Initial value
+    val usernameSize: State<Float> = _usernameSize
+
+
+    private val _messageSize = mutableStateOf(15f)  // Initial value
+    val messageSize: State<Float> = _messageSize
+
+
+    private val _lineHeight= mutableStateOf((15f *1.6f))  // Initial value
+    val lineHeight: State<Float> = _lineHeight
+
+    private val _customUsernameColor= mutableStateOf(true)  // Initial value
+    val customUsernameColor: State<Boolean> = _customUsernameColor
+
     fun changeBadgeSize(newValue:Float){
         Log.d("changeBadgeSizeViewMode","newValue ->${newValue}")
         _badgeSize.value = newValue
+    }
+    fun changeEmoteSize(newValue:Float){
+        _emoteSize.value = newValue
+
+    }
+    fun changeUsernameSize(newValue:Float){
+        _usernameSize.value = newValue
+    }
+    fun changeMessageSize(newValue:Float){
+        _messageSize.value = newValue
+    }
+    fun changeLineHeight(newValue:Float){
+        _lineHeight.value = newValue
+    }
+    fun changeCustomUsernameColor(newValue:Boolean){
+        _customUsernameColor.value = newValue
     }
 
 }


### PR DESCRIPTION
# Related Issue
- #1653


# Proposed changes
- moving all the values related to the `SliderAdvanced` composable into a viewmodel


# Additional context(optional)
- n/a
