### PR TITLE
allowing the chat badgesize to be stored locally

### DIFF
--- a/app/src/main/java/com/example/clicker/data/TokenDataStore.kt
+++ b/app/src/main/java/com/example/clicker/data/TokenDataStore.kt
@@ -1,12 +1,15 @@
 package com.example.clicker.data
 
 import android.content.Context
+import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.example.clicker.domain.ChatSettingsDataStore
 import com.example.clicker.domain.TwitchDataStore
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -19,7 +22,7 @@ val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "to
 
 class TokenDataStore @Inject constructor(
     private val context: Context
-):TwitchDataStore {
+):TwitchDataStore,ChatSettingsDataStore {
 
     private val _oneClickActionState = MutableStateFlow(false)
      val oneClickActionState = _oneClickActionState.asStateFlow() // this is the text data shown to the user
@@ -32,6 +35,8 @@ class TokenDataStore @Inject constructor(
     private val userLoggedOutStatusKey = booleanPreferencesKey("user_logged_out_loading_status")
 
     private val clientIdKey = stringPreferencesKey("client_id")
+
+    private val badgeSizeIdKey = floatPreferencesKey("badge_size_id")
 
 
     override suspend fun setOAuthToken(oAuthToken: String) {
@@ -110,6 +115,30 @@ class TokenDataStore @Inject constructor(
                 preferences[clientIdKey] ?: ""
             }
         return clientId
+    }
+
+    override suspend fun setBadgeSize(badgeSize: Float) {
+        try {
+            context.dataStore.edit { tokens ->
+                tokens[badgeSizeIdKey] = badgeSize
+            }
+            Log.d("TokenDataStoreException", "SUCCESS")
+        } catch (e: Exception) {
+            Log.d("TokenDataStoreException", "Error setting badge size")
+            Log.d("TokenDataStoreException", "cause-> ${e.cause}")
+            Log.d("TokenDataStoreException", "localizedMessage-> ${e.localizedMessage}")
+            Log.d("TokenDataStoreException", "message-> ${e.message}")
+            Log.d("TokenDataStoreException", "stackTrace-> ${e.stackTrace}")
+        }
+
+    }
+
+    override fun getBadgeSize(): Flow<Float> {
+        val badgeSize: Flow<Float> = context.dataStore.data
+            .map { preferences ->
+                preferences[badgeSizeIdKey] ?: 20f
+            }
+        return badgeSize
     }
 }
 

--- a/app/src/main/java/com/example/clicker/di/modules/SingletonModule.kt
+++ b/app/src/main/java/com/example/clicker/di/modules/SingletonModule.kt
@@ -3,6 +3,7 @@ package com.example.clicker.di.modules
 import android.content.Context
 import android.util.Log
 import com.example.clicker.data.TokenDataStore
+import com.example.clicker.domain.ChatSettingsDataStore
 import com.example.clicker.domain.TwitchDataStore
 import com.example.clicker.network.clients.BetterTTVEmoteClient
 import com.example.clicker.network.clients.TwitchAuthenticationClient
@@ -45,6 +46,7 @@ import com.example.clicker.network.websockets.TwitchEventSubWebSocket
 import com.example.clicker.presentation.AuthenticationEvent
 import com.example.clicker.presentation.AuthenticationEventBus
 import com.example.clicker.presentation.stream.util.NetworkMonitoring
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -164,6 +166,11 @@ object SingletonModule {
             .build().create(TwitchModClient::class.java)
     }
 
+    @Provides
+    @Singleton
+    fun provideContext(@ApplicationContext context: Context): Context {
+        return context
+    }
     @Singleton
     @Provides
     fun providesTokenDataStore(
@@ -171,6 +178,16 @@ object SingletonModule {
     ): TwitchDataStore {
         return TokenDataStore(appContext)
     }
+    @Singleton
+    @Provides
+    fun providesChatSettingsDataStore(
+        twitchTokenDataStore: TokenDataStore
+    ): ChatSettingsDataStore {
+        return twitchTokenDataStore
+    }
+
+
+
 
     @Singleton
     @Provides
@@ -215,7 +232,7 @@ object SingletonModule {
         tokenDataStore: TwitchDataStore,
         twitchParsingEngine: ParsingEngine
     ): TwitchSocket {
-        return TwitchWebSocket(tokenDataStore,twitchParsingEngine)
+        return TwitchWebSocket(twitchParsingEngine)
     }
 
 
@@ -250,3 +267,4 @@ object SingletonModule {
 
 
 }
+

--- a/app/src/main/java/com/example/clicker/domain/ChatSettingsDataStore.kt
+++ b/app/src/main/java/com/example/clicker/domain/ChatSettingsDataStore.kt
@@ -1,0 +1,11 @@
+package com.example.clicker.domain
+
+import kotlinx.coroutines.flow.Flow
+
+interface ChatSettingsDataStore {
+
+    suspend fun setBadgeSize(badgeSize: Float)
+
+    fun getBadgeSize(): Flow<Float>
+
+}

--- a/app/src/main/java/com/example/clicker/domain/TwitchDataStore.kt
+++ b/app/src/main/java/com/example/clicker/domain/TwitchDataStore.kt
@@ -38,4 +38,5 @@ interface TwitchDataStore {
 
 
 
+
 }

--- a/app/src/main/java/com/example/clicker/network/domain/TwitchSocket.kt
+++ b/app/src/main/java/com/example/clicker/network/domain/TwitchSocket.kt
@@ -58,7 +58,8 @@ interface TwitchSocket {
      * */
     fun run(
         channelName: String?,
-        username: String
+        username: String,
+        oAuthToken:String,
     ): Unit
 
     /**

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -240,6 +240,7 @@ fun StreamView(
 
 
 
+
     val showWarnDialog = remember{ mutableStateOf(false) }
     var orientation by remember { mutableStateOf(Configuration.ORIENTATION_PORTRAIT) }
     val configuration = LocalConfiguration.current

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -554,24 +554,25 @@ class StreamViewModel @Inject constructor(
         }
     }
 
+    //for right now this has been removed 2024-08-24
     //todo:THIS IS THE MONITORING of the network status
     init{
-        viewModelScope.launch {
-            networkMonitoring.networkStatus.collect{nullableValue ->
-                nullableValue?.also{nonNullableValue ->
-                    _uiState.value = _uiState.value.copy(
-                        networkStatus = nonNullableValue
-                    )
-                    if(nullableValue){
-                        val username =_uiState.value.login
-                        val channelName = _channelName.value?:""
-                        webSocket.run(channelName, username)
-                    }
-
-                }
-
-            }
-        }
+//        viewModelScope.launch {
+//            networkMonitoring.networkStatus.collect{nullableValue ->
+//                nullableValue?.also{nonNullableValue ->
+//                    _uiState.value = _uiState.value.copy(
+//                        networkStatus = nonNullableValue
+//                    )
+//                    if(nullableValue){
+//                        val username =_uiState.value.login
+//                        val channelName = _channelName.value?:""
+//                        webSocket.run(channelName, username)
+//                    }
+//
+//                }
+//
+//            }
+//        }
     }
 
     fun getGlobalChatBadges(
@@ -1091,6 +1092,8 @@ class StreamViewModel @Inject constructor(
      * */
     private fun startWebSocket(channelName: String) = viewModelScope.launch {
         Log.d("startWebSocket", "startWebSocket() is being called")
+        val oAuthToken =_uiState.value.oAuthToken
+
 
         if(_advancedChatSettingsState.value.noChatMode){
             //this is meant to be empty to represent doing nothing and the user being in no chat mode
@@ -1098,7 +1101,7 @@ class StreamViewModel @Inject constructor(
         }else{
 
             val username = _uiState.value.login
-            webSocket.run(channelName, username)
+            webSocket.run(channelName, username,oAuthToken)
             listChats.clear()
         }
     }


### PR DESCRIPTION
# Related Issue
- #1653 


# Proposed changes
- removed the token datastore from the websocket
- adding the `ChatSettingsDataStore` interface 


# Additional context(optional)
- n/a
