### PR TITLE
moving the clicked streamer name logic to viewModel

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
@@ -88,6 +88,7 @@ fun ValidationView(
         onNavigate = {id -> onNavigate(id) },
         updateStreamerName = { streamerName, clientId, broadcasterId, userId ->
             if (!lowPowerModeActive) {
+                homeViewModel.updateClickedStreamerName(streamerName)
 
                 Log.d("LOWPOWERMODETESTING", "NON-ACTIVE")
                 streamViewModel.updateChannelNameAndClientIdAndUserId(

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -115,6 +115,14 @@ class HomeViewModel @Inject constructor(
     ))
     val offlineFollowedStreams: State<AllFollowedStreamers> = _offlineFollowedStreams
 
+    private var _clickedStreamerName: MutableState<String> = mutableStateOf("")
+    val clickedStreamerName: State<String> = _clickedStreamerName
+
+    fun updateClickedStreamerName(clickedUsername:String){
+        _clickedStreamerName.value = clickedUsername
+    }
+
+
 
     /**BELOW IS THE NETWORK REQUEST BUILDER*/
 

--- a/app/src/main/java/com/example/clicker/presentation/horizontalStreamOverlay/OverlayStreamRow.kt
+++ b/app/src/main/java/com/example/clicker/presentation/horizontalStreamOverlay/OverlayStreamRow.kt
@@ -55,6 +55,8 @@ fun OverlayStreamRow(
 ){
     val height = homeViewModel.state.value.aspectHeight
     val width = homeViewModel.state.value.width
+
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -98,6 +100,8 @@ fun OverlayStreamRow(
 
         },
         updateClickedStreamInfo ={value -> updateClickedStreamInfo(value)},
+        clickedStreamName = homeViewModel.clickedStreamerName.value,
+        updateClickedStreamerName = {clickedName ->homeViewModel.updateClickedStreamerName(clickedName)}
     )
 
 
@@ -117,8 +121,10 @@ fun LazyRowViewTesting(
     updateStreamerName: (String, String, String, String) -> Unit,
     getChannelEmotes:(String) ->Unit,
     updateClickedStreamInfo:(ClickedStreamInfo)->Unit,
+    clickedStreamName:String,
+    updateClickedStreamerName:(String) ->Unit
 ){
-    var clickedStreamName by remember { mutableStateOf("") }
+
     LazyRow(modifier = Modifier
         .fillMaxSize()
         .padding(10.dp)) {
@@ -158,7 +164,7 @@ fun LazyRowViewTesting(
                         },
                         reconnectWebSocketChat ={channelName ->reconnectWebSocketChat(channelName)},
                         clickedStreamName=clickedStreamName,
-                        updateClickedStreamerName = {streamerName -> clickedStreamName = streamerName}
+                        updateClickedStreamerName = {streamerName -> updateClickedStreamerName(streamerName)}
                     )
                 }
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/horizontalLongPress/LongPress.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/horizontalLongPress/LongPress.kt
@@ -142,6 +142,7 @@ fun HorizontalLongPressView(
                                     updateStreamerName(streamerName,clientId,broadcasterId,userId)
                                     Log.d("horizontalNavigation","CLICKING")
                                     streamViewModel.clearAllChatters()
+                                    homeViewModel.updateClickedStreamerName(streamerName)
 
                                 },
                                 clientId =clientId,
@@ -193,6 +194,7 @@ fun TestingLazyColumnItem(
     clientId: String,
     userId:String,
     updateStreamerName: (String, String, String, String) -> Unit,
+
     ){
     LazyColumn(
         modifier = Modifier


### PR DESCRIPTION
# Related Issue
- #1695


# Proposed changes
- moving the clicked streamer name logic to the stream ViewModel


# Additional context(optional)
- n/a
