### PR TITLE
moving the getting global emotes call

### DIFF
--- a/app/src/main/java/com/example/clicker/network/repository/TwitchEmotImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchEmotImpl.kt
@@ -212,12 +212,16 @@ class TwitchEmoteImpl @Inject constructor(
         clientId: String,
     ): Flow<Response<Boolean>> = flow {
         emit(Response.Loading)
+        Log.d("getGlobalEmotes","OAUTHTOKEN ->${oAuthToken}")
+        Log.d("getGlobalEmotes","clientId ->${clientId}")
+
          val response = twitchEmoteClient.getGlobalEmotes(
              authorization = "Bearer $oAuthToken",
              clientId = clientId
          )
 
           if (response.isSuccessful) {
+              Log.d("getGlobalEmotes","SUCCESS")
               val data = response.body()?.data ?: listOf()
               if(data.isNotEmpty()){
                   val parsedEmoteData = data.map {

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeView.kt
@@ -90,6 +90,7 @@ fun ValidationView(
             if (!lowPowerModeActive) {
                 homeViewModel.updateClickedStreamerName(streamerName)
 
+
                 Log.d("LOWPOWERMODETESTING", "NON-ACTIVE")
                 streamViewModel.updateChannelNameAndClientIdAndUserId(
                     streamerName,
@@ -118,6 +119,10 @@ fun ValidationView(
                     streamViewModel.state.value.broadcasterId,
                 )
                 chatSettingsViewModel.getGlobalChatBadges(
+                    oAuthToken = homeViewModel.state.value.oAuthToken,
+                    clientId = streamViewModel.state.value.clientId,
+                )
+                chatSettingsViewModel.getGlobalEmote(
                     oAuthToken = homeViewModel.state.value.oAuthToken,
                     clientId = streamViewModel.state.value.clientId,
                 )

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeViewModel.kt
@@ -51,7 +51,6 @@ class HomeViewModel @Inject constructor(
     private val ioDispatcher: CoroutineDispatcher,
     private val tokenDataStore: TwitchDataStore,//todo:TEST-> needs to be done as an instrumented tests
     private val authentication: TwitchAuthentication,//todo:TEST(DONE)
-    private val twitchEmoteImpl: TwitchEmoteRepo,//todo:TEST(DONE)
 ) : ViewModel() {
 
     private var _uiState: MutableState<HomeUIState> = mutableStateOf(HomeUIState())
@@ -149,7 +148,7 @@ class HomeViewModel @Inject constructor(
                     userId = _validatedUser.value?.userId ?:"",
                     oAuthToken = _oAuthToken.value ?: "",
                 )
-                getGlobalEmote(_oAuthToken.value ?: "",_validatedUser.value?.clientId ?:"")
+               // getGlobalEmote(_oAuthToken.value ?: "",_validatedUser.value?.clientId ?:"")
             }
 
         }
@@ -254,7 +253,7 @@ class HomeViewModel @Inject constructor(
                         userId = nonNullValidatedUser.userId,
                         oAuthToken = _uiState.value.oAuthToken
                     )
-                    getGlobalEmote(_uiState.value.oAuthToken,nonNullValidatedUser.clientId)
+                   // getGlobalEmote(_uiState.value.oAuthToken,nonNullValidatedUser.clientId)
                 }
             }
         }
@@ -286,27 +285,8 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    //
-    private fun getGlobalEmote(oAuthToken:String,clientId: String) {
+    //todo: this needs to get moved
 
-        viewModelScope.launch {
-            withContext(Dispatchers.IO){
-                twitchEmoteImpl.getGlobalEmotes(
-                    oAuthToken, clientId
-                ).mapWithRetry(
-                    action={
-                        // result is the result from getGlobalEmotes()
-                            result -> result
-                    },
-                    predicate = { result, attempt ->
-                        val repeatResult = result is Response.Failure && attempt < 3
-                        repeatResult
-                    }
-                ).collect{}
-            }
-
-        }
-    }
 
 
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/chatSettings/ChatSettingsViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/chatSettings/ChatSettingsViewModel.kt
@@ -36,6 +36,7 @@ import com.example.clicker.network.domain.TwitchEmoteRepo
 import com.example.clicker.network.repository.EmoteListMap
 import com.example.clicker.network.repository.EmoteNameUrl
 import com.example.clicker.util.Response
+import com.example.clicker.util.mapWithRetry
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -43,6 +44,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.LinkedList
 import java.util.Queue
 import javax.inject.Inject
@@ -470,6 +472,31 @@ class ChatSettingsViewModel @Inject constructor(
         }.toMap()
 
         return newMap
+
+    }
+
+     fun getGlobalEmote(oAuthToken:String,clientId: String) {
+
+         if(globalEmoteList.isEmpty()){
+             viewModelScope.launch {
+                 withContext(Dispatchers.IO){
+                     twitchEmoteImpl.getGlobalEmotes(
+                         oAuthToken, clientId
+                     ).mapWithRetry(
+                         action={
+                             // result is the result from getGlobalEmotes()
+                                 result -> result
+                         },
+                         predicate = { result, attempt ->
+                             val repeatResult = result is Response.Failure && attempt < 3
+                             repeatResult
+                         }
+                     ).collect{}
+                 }
+
+             }
+         }
+
 
     }
 


### PR DESCRIPTION
# Related Issue
- n/a


# Proposed changes
- moving the `getGlobalEmote()` call to the chatsettings viewModel


# Additional context(optional)
- n/a
