### PR TITLE
remove channel emote from most recent emotes

### DIFF
--- a/app/src/main/java/com/example/clicker/network/domain/TwitchEmoteRepo.kt
+++ b/app/src/main/java/com/example/clicker/network/domain/TwitchEmoteRepo.kt
@@ -88,7 +88,8 @@ interface TwitchEmoteRepo {
     fun getChannelEmotes(
         oAuthToken: String,
         clientId: String,
-        broadcasterId:String
+        broadcasterId:String,
+        channelName:String,
     ): Flow<Response<Boolean>>
 
 

--- a/app/src/main/java/com/example/clicker/network/repository/TwitchEmotImpl.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/TwitchEmotImpl.kt
@@ -259,7 +259,7 @@ class TwitchEmoteImpl @Inject constructor(
 
 
     override fun getChannelEmotes(
-        oAuthToken: String, clientId: String,broadcasterId:String
+        oAuthToken: String, clientId: String,broadcasterId:String,channelName: String
     ): Flow<Response<Boolean>> =flow{
         emit(Response.Loading)
         val response = twitchEmoteClient.getChannelEmotes(
@@ -274,7 +274,7 @@ class TwitchEmoteImpl @Inject constructor(
             if(data.isNotEmpty()){
                // Log.d("CheckkinggetChannelEmotes","emotes ->${data}")
 
-                val parsedEmoteData = convertDataToEmoteNameUrlEmoteType(data)
+                val parsedEmoteData = convertDataToEmoteNameUrlEmoteType(data,channelName)
                 val newChannelEmoteList = parsedEmoteData.map{
 
                     EmoteNameUrl(
@@ -312,11 +312,17 @@ class TwitchEmoteImpl @Inject constructor(
         emit(Response.Failure(Exception("Unable to get emotes")))
     }
     private fun convertDataToEmoteNameUrlEmoteType(
-        data: List<ChannelEmote>
+        data: List<ChannelEmote>,
+        channelName:String,
     ): List<EmoteNameUrlEmoteType>{
        return data.map {// getting data from the request
             val emoteType = if(it.emote_type =="subscriptions") EmoteTypes.SUBS else EmoteTypes.FOLLOWERS
-            EmoteNameUrlEmoteType(it.name,it.images.url_1x,emoteType)
+            EmoteNameUrlEmoteType(
+                it.name,
+                it.images.url_1x,
+                emoteType,
+                channelName = channelName
+            )
         }
 
     }

--- a/app/src/main/java/com/example/clicker/network/repository/models/EmoteModels.kt
+++ b/app/src/main/java/com/example/clicker/network/repository/models/EmoteModels.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Immutable
 import com.example.clicker.network.models.emotes.IndivBetterTTVEmote
 
 
-
 /**
  * EmoteNameEmoteType represents a single Twitch Emote from the Twitch servers, when calling get channel emotes
  * - you can read more about getting channel emotes, [HERE](https://dev.twitch.tv/docs/api/reference/#get-channel-emotes)
@@ -17,7 +16,8 @@ import com.example.clicker.network.models.emotes.IndivBetterTTVEmote
 data class EmoteNameUrlEmoteType(
     val name:String,
     val url:String,
-    val emoteType:EmoteTypes
+    val emoteType:EmoteTypes,
+    val channelName:String =""
 )
 
 /**
@@ -37,6 +37,7 @@ data class EmoteNameUrlList(
     val list:List<EmoteNameUrl> = listOf()
 )
 
+
 /**
  * EmoteNameUrl represents a single Twitch Emote from the Twitch servers. Each instance of this class is a unique Emote
  *
@@ -46,6 +47,7 @@ data class EmoteNameUrlList(
 data class EmoteNameUrl(
     val name:String,
     val url:String,
+    val channelName: String=""
 )
 
 

--- a/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
@@ -574,6 +574,7 @@ fun ModViewComponentVersionThree(
                         channelBetterTTVEmoteContentMap =chatSettingsViewModel.betterTTVChannelInlineContentMapChannelEmoteList.value,
                         sharedBetterTTVEmoteContentMap =chatSettingsViewModel.betterTTVSharedInlineContentMapChannelEmoteList.value,
                         lowPowerMode= streamViewModel.lowPowerModeActive.value,
+                        channelName = streamViewModel.channelName.value ?:""
 
                         )
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/HorizontalChat.kt
@@ -335,9 +335,7 @@ fun HorizontalChat(
                 channelBetterTTVEmoteContentMap =chatSettingsViewModel.betterTTVChannelInlineContentMapChannelEmoteList.value,
                 sharedBetterTTVEmoteContentMap =chatSettingsViewModel.betterTTVSharedInlineContentMapChannelEmoteList.value,
                 lowPowerMode= streamViewModel.lowPowerModeActive.value,
-
-
-
+                channelName = streamViewModel.channelName.value ?:""
 
             )
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamView.kt
@@ -457,6 +457,7 @@ fun StreamView(
                             channelBetterTTVEmoteContentMap =chatSettingsViewModel.betterTTVChannelInlineContentMapChannelEmoteList.value,
                             sharedBetterTTVEmoteContentMap =chatSettingsViewModel.betterTTVSharedInlineContentMapChannelEmoteList.value,
                             lowPowerMode= streamViewModel.lowPowerModeActive.value,
+                            channelName = streamViewModel.channelName.value ?:""
                         )
 
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamViewModel.kt
@@ -22,7 +22,9 @@ import com.example.clicker.network.models.twitchStream.ChatSettingsData
 import com.example.clicker.network.domain.TwitchSocket
 import com.example.clicker.network.models.websockets.TwitchUserData
 import com.example.clicker.network.repository.models.EmoteNameUrl
+import com.example.clicker.network.repository.models.EmoteNameUrlEmoteType
 import com.example.clicker.network.repository.models.EmoteNameUrlList
+import com.example.clicker.network.repository.models.EmoteTypes
 
 import com.example.clicker.network.websockets.MessageScanner
 import com.example.clicker.network.websockets.models.MessageToken
@@ -58,6 +60,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+
+
 
 
 
@@ -136,7 +141,10 @@ class StreamViewModel @Inject constructor(
      * A list representing all the most recent clicked emotes
      * */
     val mostFrequentEmoteListTesting = mutableStateOf(EmoteNameUrlList())
+
+
     private val temporaryMostFrequentList = mutableStateListOf<EmoteNameUrl>()
+
 
     /**
      * A list representing all the chats users have sent
@@ -381,6 +389,7 @@ class StreamViewModel @Inject constructor(
                 _channelName.collect { channelName ->
                     channelName?.let {
                         startWebSocket(channelName)
+                        filterOutChannelEmotesFromMostRecentList(channelName)
                     }
                 }
             }
@@ -536,6 +545,16 @@ class StreamViewModel @Inject constructor(
 
 
     }
+    private fun filterOutChannelEmotesFromMostRecentList(channelName: String){
+        val oldListMapped = mostFrequentEmoteListTesting.value.list
+
+        mostFrequentEmoteListTesting.value = mostFrequentEmoteListTesting.value.copy(
+            list =oldListMapped.filter{it.channelName =="GLOBAL"}
+        )
+        temporaryMostFrequentList.clear()
+
+
+    }
 
     /**
      *  a function used to update [_clickedStreamInfo]
@@ -678,6 +697,7 @@ class StreamViewModel @Inject constructor(
         clientId: String,
         broadcasterId: String
     ){
+        Log.d("getChannelEmotesChannelEmotes","channel name -> ${_channelName.value}")
 //        Log.d("getGlobalEmotes","oAuthToken-->${oAuthToken}")
 //        Log.d("getGlobalEmotes","clientId ->$clientId")
 //        Log.d("getGlobalEmotes","broadcasterId ->$broadcasterId")
@@ -685,7 +705,7 @@ class StreamViewModel @Inject constructor(
         viewModelScope.launch {
             withContext(ioDispatcher){
                 twitchEmoteImpl.getChannelEmotes(
-                    oAuthToken,clientId,broadcasterId
+                    oAuthToken,clientId,broadcasterId,_channelName.value?:""
                 ).mapWithRetry(
                     action={
                         // result is the result from getChannelEmotes()
@@ -936,6 +956,7 @@ class StreamViewModel @Inject constructor(
      *
      * */
     fun addEmoteToText(emoteText:String){
+        Log.d("ChannelNameTest","_channelName ->${_channelName.value}")
         textParsing.updateTextFieldWithEmote(" $emoteText")
     }
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/FullChatModView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/FullChatModView.kt
@@ -52,7 +52,7 @@ fun FullChatModView(
     hideSoftKeyboard:()-> Unit,
     emoteBoardGlobalList: EmoteNameUrlList,
     emoteBoardChannelList: EmoteNameUrlEmoteTypeList,
-    emoteBoardMostFrequentList: EmoteNameUrlList,
+    emoteBoardMostFrequentList:  EmoteNameUrlList,
     updateMostFrequentEmoteList:(EmoteNameUrl)->Unit,
     updateTextWithEmote:(String) ->Unit,
     deleteEmote:()->Unit,
@@ -77,6 +77,7 @@ fun FullChatModView(
     channelBetterTTVEmoteContentMap: EmoteListMap,
     sharedBetterTTVEmoteContentMap: EmoteListMap,
     lowPowerMode:Boolean,
+    channelName:String,
 
     ){
     val lazyColumnListState = rememberLazyListState()
@@ -212,7 +213,8 @@ fun FullChatModView(
         sharedBetterTTVResponse=sharedBetterTTVResponse,
         userIsSub = userIsSub,
         forwardSlashes = forwardSlashes,
-        lowPowerMode = lowPowerMode
+        lowPowerMode = lowPowerMode,
+        channelName = channelName
 
 
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/views/chat/ImprovedChatUI.kt
@@ -145,7 +145,6 @@ fun ChatUI(
     showBanDialog:()->Unit,
     doubleClickMessage:(String)->Unit,
 
-
     //below is what is needed for the chat UI
     textFieldValue: MutableState<TextFieldValue>,
     clickedAutoCompleteText: (String) -> Unit,
@@ -186,6 +185,7 @@ fun ChatUI(
     channelBetterTTVEmoteContentMap:EmoteListMap,
     sharedBetterTTVEmoteContentMap:EmoteListMap,
     lowPowerMode:Boolean,
+    channelName:String,
 
 
     ){
@@ -331,7 +331,8 @@ fun ChatUI(
         sharedBetterTTVResponse=sharedBetterTTVResponse,
         userIsSub=userIsSub,
         forwardSlashes=forwardSlashes,
-        lowPowerMode=lowPowerMode
+        lowPowerMode=lowPowerMode,
+        channelName=channelName
 
         )
 }
@@ -362,6 +363,7 @@ fun ChatUIBox(
     deleteEmote:()->Unit,
     userIsSub:Boolean,
     forwardSlashes: ForwardSlashCommandsImmutableCollection,
+    channelName:String,
 ){
     val titleFontSize = MaterialTheme.typography.headlineMedium.fontSize
     val messageFontSize = MaterialTheme.typography.headlineSmall.fontSize
@@ -420,6 +422,7 @@ fun ChatUIBox(
                             channelBetterTTVResponse = channelBetterTTVResponse,
                             sharedBetterTTVResponse = sharedBetterTTVResponse,
                             userIsSub = userIsSub,
+                            channelName=channelName
 
                             )
 
@@ -477,8 +480,9 @@ fun EmoteBoard(
     closeEmoteBoard: () -> Unit,
     deleteEmote:()->Unit,
     userIsSub:Boolean,
+    channelName:String,
 
-){
+    ){
     Log.d("FlowRowSimpleUsageExampleClicked", "EmoteBoard recomp")
     val lazyGridState = rememberLazyGridState()
     val betterTTVLazyGridState = rememberLazyGridState()
@@ -548,7 +552,8 @@ fun EmoteBoard(
                                         updateTempararyMostFrequentEmoteList(value)
                                     },
                                     modifier = Modifier.padding(bottom = 50.dp),
-                                    userIsSub=userIsSub
+                                    userIsSub=userIsSub,
+                                    channelName=channelName
 
                                 )
                                 EmoteBottomUI(
@@ -591,6 +596,7 @@ fun EmoteBoard(
                                 betterTTVLazyGridState=betterTTVLazyGridState,
                                 updateTempararyMostFrequentEmoteList={usedEmote->updateTempararyMostFrequentEmoteList(usedEmote)},
                                 modifier = Modifier.padding(bottom = 50.dp),
+                                channelName=channelName
 
                             )
                             BetterTTVEmoteBottomUI(
@@ -645,6 +651,7 @@ fun BetterTTVEmoteBoard(
     betterTTVLazyGridState: LazyGridState,
     updateTextWithEmote: (String) -> Unit,
     updateTempararyMostFrequentEmoteList:(EmoteNameUrl)->Unit,
+    channelName:String,
     modifier:Modifier
 
 ){
@@ -696,7 +703,8 @@ fun BetterTTVEmoteBoard(
                             updateTempararyMostFrequentEmoteList(
                                 EmoteNameUrl(
                                     name=it.code,
-                                    url ="https://cdn.betterttv.net/emote/${it.id}/1x"
+                                    url ="https://cdn.betterttv.net/emote/${it.id}/1x",
+                                    channelName = channelName
                                 )
                             )
                         }
@@ -736,7 +744,8 @@ fun BetterTTVEmoteBoard(
                     updateTempararyMostFrequentEmoteList(
                         EmoteNameUrl(
                             name=it.code,
-                            url ="https://cdn.betterttv.net/emote/${it.id}/1x"
+                            url ="https://cdn.betterttv.net/emote/${it.id}/1x",
+                            channelName = channelName
                         )
                     )
                 }
@@ -781,7 +790,8 @@ fun BetterTTVEmoteBoard(
                             updateTempararyMostFrequentEmoteList(
                                 EmoteNameUrl(
                                     name=it.code,
-                                    url ="https://cdn.betterttv.net/emote/${it.id}/1x"
+                                    url ="https://cdn.betterttv.net/emote/${it.id}/1x",
+                                    channelName="GLOBAL"
                                 )
                             )
                         }
@@ -1021,7 +1031,6 @@ fun BetterTTVEmoteBottomUI(
  * - restartable
  * - skippable
  * */
-@OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun LazyGridEmotes(
     emoteBoardGlobalList: EmoteNameUrlList,
@@ -1032,6 +1041,7 @@ fun LazyGridEmotes(
 
     lazyGridState: LazyGridState,
     userIsSub:Boolean,
+    channelName:String,
     modifier:Modifier,
 ) {
 
@@ -1171,7 +1181,11 @@ fun LazyGridEmotes(
                         .clickable {
                             updateTextWithEmote(it.name)
                             updateTempararyMostFrequentEmoteList(
-                                EmoteNameUrl(it.name, it.url)
+                                EmoteNameUrl(
+                                    it.name,
+                                    it.url,
+                                    channelName = channelName
+                                )
                             )
                         }
                 )
@@ -1217,7 +1231,7 @@ fun LazyGridEmotes(
                     .clickable {
                         updateTextWithEmote(it.name)
                         updateTempararyMostFrequentEmoteList(
-                            EmoteNameUrl(it.name, it.url)
+                            EmoteNameUrl(it.name, it.url,"GLOBAL")
                         )
                     }
             )


### PR DESCRIPTION
# Related Issue
- #1763 


# Proposed changes
- added `channelName` to the `EmoteNameUrlEmoteType` class
- added `filterOutChannelEmotesFromMostRecentList()` to do the actual functionality 



# Additional context(optional)
- n/a
