### PR TITLE
removing the subscription status

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
+++ b/app/src/main/java/com/example/clicker/presentation/modChannels/modVersionThree/ModVersionThree.kt
@@ -3162,13 +3162,6 @@ fun NewContentBanner(
         Text("Account created at: 2024-09-18", fontSize = MaterialTheme.typography.headlineSmall.fontSize,color = MaterialTheme.colorScheme.onPrimary)
         Spacer(modifier = Modifier.height(1.dp).fillMaxWidth().background(MaterialTheme.colorScheme.secondary))
         Spacer(modifier = Modifier.height(10.dp))
-
-        Text("Subscriber: true", fontSize = MaterialTheme.typography.headlineSmall.fontSize,color = MaterialTheme.colorScheme.onPrimary)
-        Spacer(modifier = Modifier.height(2.dp))
-        Text("Is Gifted: false", fontSize = MaterialTheme.typography.headlineSmall.fontSize,color = MaterialTheme.colorScheme.onPrimary)
-        Spacer(modifier = Modifier.height(2.dp))
-        Text("Tier: 3", fontSize = MaterialTheme.typography.headlineSmall.fontSize,color = MaterialTheme.colorScheme.onPrimary)
-        Spacer(modifier = Modifier.height(2.dp))
         Text("Unban request message: Please, Please let me in!!!!!!!!!!!!!!!!!! let me in. I did not do it. I did not. Oh, hi mark!", fontSize = MaterialTheme.typography.headlineSmall.fontSize,color = MaterialTheme.colorScheme.onPrimary)
         Spacer(modifier = Modifier.height(10.dp))
 


### PR DESCRIPTION
# Related Issue
- #1823


# Proposed changes
- removing all the Ui for checking user's subscription status
- unfortunately, this feature can not be completed. `Check User Subscription` can only be completed with a user_id matching what is found in the oAuth token. Meaning that you can only check the subscribed status of the logged in user and not other users


# Additional context(optional)
- n/a
