### PR TITLE
adding the BroadcastReceiver to shut down service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,6 +58,10 @@
             android:foregroundServiceType="mediaPlayback"
             android:exported="false">
         </service>
+        <!-- If this receiver listens for broadcasts sent from the system or from
+     other apps, even other apps that you own, set android:exported to "true". -->
+        <receiver android:name=".broadcastReceivers.ShutDownBroadcastReceiver" android:exported="false">
+        </receiver>
     </application>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />

--- a/app/src/main/java/com/example/clicker/MainActivity.kt
+++ b/app/src/main/java/com/example/clicker/MainActivity.kt
@@ -132,6 +132,7 @@ private fun testingPermissionAgain(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 
 
+
             val channel = NotificationChannel(
                 "CHANNEL_ID",
                 "Background Audio",
@@ -142,6 +143,15 @@ private fun testingPermissionAgain(context: Context) {
             val notificationManager = getSystemService(NotificationManager::class.java)
             notificationManager.createNotificationChannel(channel)
         }
+    }
+
+    fun deleteNotificationChannel(){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val id: String = "CHANNEL_ID"
+            notificationManager.deleteNotificationChannel(id)
+        }
+
     }
 
 

--- a/app/src/main/java/com/example/clicker/broadcastReceivers/ShutDownBroadcastReceiver.kt
+++ b/app/src/main/java/com/example/clicker/broadcastReceivers/ShutDownBroadcastReceiver.kt
@@ -1,0 +1,21 @@
+package com.example.clicker.broadcastReceivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.example.clicker.services.BackgroundStreamService
+
+class ShutDownBroadcastReceiver : BroadcastReceiver() {
+
+
+    override fun onReceive(p0: Context?, p1: Intent?) {
+        Log.d("ShutDownBroadcastReceiver","SHUT IT DOWN!!!!!!!!!!")
+        p0?.let{context ->
+            val startIntent = Intent(context, BackgroundStreamService::class.java)
+            startIntent.action = BackgroundStreamService.Actions.END.toString()
+            context.startService(startIntent)
+        }
+
+    }
+}

--- a/app/src/main/java/com/example/clicker/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/home/HomeFragment.kt
@@ -160,7 +160,7 @@ class HomeFragment : Fragment(){
                                 startIntent.action = BackgroundStreamService.Actions.START.toString()
                                 context.startService(startIntent)
 
-                               // testingPermissionAgain(requireContext())
+
                                          },
                             endService={
                                 val startIntent = Intent(context, BackgroundStreamService::class.java)

--- a/app/src/main/java/com/example/clicker/services/BackgroundStreamService.kt
+++ b/app/src/main/java/com/example/clicker/services/BackgroundStreamService.kt
@@ -33,6 +33,7 @@ import androidx.core.graphics.drawable.IconCompat
 import androidx.core.graphics.drawable.toBitmap
 import com.example.clicker.MainActivity
 import com.example.clicker.R
+import com.example.clicker.broadcastReceivers.ShutDownBroadcastReceiver
 import com.example.clicker.presentation.stream.AndroidConsoleInterface
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -171,22 +172,37 @@ class BackgroundStreamService: Service() {
 
             webView.loadUrl("https://player.twitch.tv/?channel=piratesoftware&controls=false&muted=false&parent=modderz")
         }
+       //todo: should be some kind of close method
     }
 
     private fun createNotification2(contentText: String): Notification {
-        val intent = Intent(this, MainActivity::class.java).apply {
-            action = ServiceActions.ACTION_SERVICE_AUDIO.toString()
+        val intent = Intent(this, ShutDownBroadcastReceiver::class.java).apply {
+            action = "com.example.broadcast.MY_NOTIFICATION"
+            putExtra("data", "Nothing to see here, move along.")
         }
 
-        val pendingIntent: PendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+        val pendingIntent: PendingIntent = PendingIntent.getBroadcast(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
         return NotificationCompat.Builder(this, "CHANNEL_ID")
             .setContentTitle("Background audio")
             .setContentText(contentText)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setOngoing(true) // Makes it non-dismissible
-            .addAction(pauseBtnIcon, "CANCEL", pendingIntent)
+            .addAction(pauseBtnIcon, "CANCEL", pendingIntent) // Action triggers broadcast
             .build()
     }
+
+
+
+
+
+
+
     private fun createNotification(): Notification {
         val intent = Intent(this, MainActivity::class.java).apply {
             action = ServiceActions.ACTION_SERVICE_AUDIO.toString()


### PR DESCRIPTION
# Related Issue
- #2059


# Proposed changes
- Creating a broadcast receiver that will shut down the service when cancel is pressed 


# Additional context(optional)
- n/a
