### PR TITLE
adding the pop inclusion for navigation

### DIFF
--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -115,6 +115,7 @@
         android:label="SelfStreamingFragment" >
         <action
             android:id="@+id/action_selfStreamingFragment_to_logoutFragment"
+            app:popUpToInclusive="true"
             app:destination="@id/logoutFragment" />
     </fragment>
 </navigation>


### PR DESCRIPTION
# Related Issue
- #2170


# Proposed changes
- added `app:popUpToInclusive="true"` to the navigation from the SelfStreamingFragment to the logout fragment 


# Additional context(optional)
- n/a
