### PR TITLE
removing the logging from the rtmp handshake

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/selfStreaming/websocket/TcpTunneledSocket.kt
+++ b/app/src/main/java/com/example/clicker/presentation/selfStreaming/websocket/TcpTunneledSocket.kt
@@ -144,7 +144,6 @@ class RtmpsClient2(
                 // Read S2
                 val s2 = ByteArray(1536)
                 inputStream.read(s2)
-                Log.d("TESTINGTHINGERSAGAIN","${s1[0]==s2[0]}")
 
                 Log.i(TAG, "RTMP handshake successful")
             } catch (e: Exception) {


### PR DESCRIPTION
# Related Issue
- n/a

# Proposed changes
- removed the logging of the s1 and s2 bytes


# Additional context(optional)
- n/a
