### PR TITLE
copying the native method

### DIFF
--- a/app/src/main/cpp/rtmp_client.cpp
+++ b/app/src/main/cpp/rtmp_client.cpp
@@ -5,22 +5,73 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "rtmp_client.h"
+
+
+
+
+#define RTMP_DEFAULT_CHUNKSIZE	128
+
+
+void RTMP_Init(RTMP *r){
+
+
+    //memset(r, 0, sizeof(RTMP));
+    r->m_sb.sb_socket = -1;
+    r->m_inChunkSize = RTMP_DEFAULT_CHUNKSIZE;
+    r->m_outChunkSize = RTMP_DEFAULT_CHUNKSIZE;
+    r->m_nBufferMS = 30000;
+    r->m_nClientBW = 2500000;
+    r->m_nClientBW2 = 2;
+    r->m_nServerBW = 2500000;
+    r->m_fAudioCodecs = 3191.0;
+    r->m_fVideoCodecs = 252.0;
+    r->Link.receiveTimeoutInMs = 10000;
+    r->Link.swfAge = 30;
+}
+int RTMP_ParseURL(const char *url, int *protocol, AVal *host, unsigned int *port,
+                  AVal *playpath, AVal *app)
+{
+    return RTMP_ERROR_UNKNOWN_RTMP_AMF_TYPE;
+}
+RTMPResult RTMP_SetupURL(RTMP *r, const char *url){
+    AVal opt, arg;
+    char *p1, *p2;
+    int ret, len;
+    unsigned int port = 0;
+
+
+
+    len = strlen(url);
+    ret = RTMP_ParseURL(url, &r->Link.protocol, &r->Link.hostname,
+                        &port, &r->Link.playpath0, &r->Link.app);
+    if (ret != RTMP_SUCCESS)
+    {
+        return (RTMPResult) ret;
+    }
+}
+
 
 
 //Now I need to make the JNI file
 extern "C"
 JNIEXPORT jint JNICALL
-Java_com_example_clicker_presentation_selfStreaming_RTMPNativeClient_nativeOpen(JNIEnv *env,
-                                                                                jobject thiz,
-                                                                                jstring url,
-                                                                                jboolean is_publish_mode,
-                                                                                jlong rtmp_pointer,
+Java_com_example_clicker_presentation_selfStreaming_RTMPNativeClient_nativeOpen(JNIEnv *env,jobject thiz,jstring url_,jboolean is_publish_mode,jlong rtmp_pointer,
                                                                                 jint send_timeout_in_ms,
                                                                                 jint receive_timeout_in_ms) {
-    RTMP *rtmp = (RTMP *) rtmpPointer;
+
+    RTMP *rtmp = new RTMP();
+    RTMP_Init(rtmp);
+    const char* url = env->GetStringUTFChars(url_, nullptr);
+
+    rtmp->Link.receiveTimeoutInMs = receive_timeout_in_ms;
+    rtmp->Link.sendTimeoutInMs = send_timeout_in_ms;
+
+    RTMPResult ret = RTMP_SetupURL(rtmp, url);
 
 
-    return -1;
+    return (int) ret;
 }
+
 

--- a/app/src/main/cpp/rtmp_client.h
+++ b/app/src/main/cpp/rtmp_client.h
@@ -15,6 +15,9 @@
 /* needs to fit largest number of bytes recv() may return */
 #define RTMP_BUFFER_CACHE_SIZE (16*1024)
 
+
+
+
 struct AVal{
     char *av_val;
     int av_len;
@@ -194,4 +197,40 @@ struct RTMP{
     RTMPSockBuf m_sb;
     RTMP_LNK Link;
 };
+typedef enum RTMPResult_ {
+    RTMP_SUCCESS = 0,
+    RTMP_READ_DONE = -1,
+    RTMP_ERROR_OPEN_ALLOC = -2,
+    RTMP_ERROR_OPEN_CONNECT_STREAM = -3,
+    RTMP_ERROR_UNKNOWN_RTMP_OPTION = -4,
+    RTMP_ERROR_UNKNOWN_RTMP_AMF_TYPE = -5,
+    RTMP_ERROR_DNS_NOT_REACHABLE = -6,
+    RTMP_ERROR_SOCKET_CONNECT_FAIL = -7,
+    RTMP_ERROR_SOCKS_NEGOTIATION_FAIL = -8,
+    RTMP_ERROR_SOCKET_CREATE_FAIL = -9,
+    RTMP_ERROR_NO_SSL_TLS_SUPP = -10,
+    RTMP_ERROR_HANDSHAKE_CONNECT_FAIL = -11,
+    RTMP_ERROR_HANDSHAKE_FAIL = -12,
+    RTMP_ERROR_CONNECT_FAIL = -13,
+    RTMP_ERROR_CONNECTION_LOST = -14,
+    RTMP_ERROR_KEYFRAME_TS_MISMATCH = -15,
+    RTMP_ERROR_READ_CORRUPT_STREAM = -16,
+    RTMP_ERROR_MEM_ALLOC_FAIL = -17,
+    RTMP_ERROR_STREAM_BAD_DATASIZE = -18,
+    RTMP_ERROR_PACKET_TOO_SMALL = -19,
+    RTMP_ERROR_SEND_PACKET_FAIL = -20,
+    RTMP_ERROR_AMF_ENCODE_FAIL = -21,
+    RTMP_ERROR_URL_MISSING_PROTOCOL = -22,
+    RTMP_ERROR_URL_MISSING_HOSTNAME = -23,
+    RTMP_ERROR_URL_INCORRECT_PORT = -24,
+    RTMP_ERROR_IGNORED = -25,
+    RTMP_ERROR_GENERIC = -26,
+    RTMP_ERROR_SANITY_FAIL = -27,
+} RTMPResult;
+void RTMP_Init(RTMP *r);
+RTMP *RTMP_Alloc(void);
+RTMPResult RTMP_SetupURL(RTMP *r, const char *url);
+int RTMP_ParseURL(const char *url, int *protocol, AVal *host,
+                  unsigned int *port, AVal *playpath, AVal *app);
+
 

--- a/app/src/main/java/com/example/clicker/presentation/selfStreaming/SelfStreamingFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/selfStreaming/SelfStreamingFragment.kt
@@ -94,7 +94,10 @@ class SelfStreamingFragment : Fragment() {
     private val mainThreadExecutor by lazy { ContextCompat.getMainExecutor(requireContext()) }
     private val captureLiveStatus = MutableLiveData<String>()
 
-
+init{
+    val another = RTMPNativeClient().nativeOpen("",false,3L,3,3)
+    Log.d("TESTINGnATIVEoPEN","return value -->$another")
+}
 
 
     private var handlerThread: HandlerThread? = null


### PR DESCRIPTION
# Related Issue
- #2247 

# Proposed changes
- copying the open method from the libRtmp-client library


# Additional context(optional)
- n/a