### PR TITLE
fix(webview): only click 18+ gate when tap lands inside its rect (#838)

### DIFF
--- a/app/src/main/java/com/example/clicker/presentation/stream/StreamFragment.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/StreamFragment.kt
@@ -651,8 +651,6 @@ class StreamFragment : Fragment() {
             }else{
                 autoModViewModel.setVerticalOverlayToVisible()
             }
-            verticalClickableWebView.evaluateJavascript("(function() { const button = document.querySelector('[data-a-target=\"content-classification-gate-overlay-start-watching-button\"]'); button && button.click(); })();", null);
-
 
             val jsCode2 = """
                  function printClickedToAndroid(quantities) {
@@ -661,6 +659,27 @@ class StreamFragment : Fragment() {
     printClickedToAndroid("Log to the console from Javascript")
  """
             verticalClickableWebView.evaluateJavascript(jsCode2, null)
+        }
+        // Issue #838: only forward the tap to the content-classification
+        // gate button when the user actually tapped inside its bounding
+        // rect. Previously every tap on the WebView click-through layer
+        // would auto-click the button.
+        verticalClickableWebView.singleTapWithCoordsMethod = { x, y ->
+            val js = """
+                (function(){
+                  var sel = '[data-a-target="content-classification-gate-overlay-start-watching-button"]';
+                  var btn = document.querySelector(sel);
+                  if (!btn) return false;
+                  var r = btn.getBoundingClientRect();
+                  var x = ${x}, y = ${y};
+                  if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
+                    btn.click();
+                    return true;
+                  }
+                  return false;
+                })();
+            """
+            verticalClickableWebView.evaluateJavascript(js, null)
         }
     }
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/customWebViews/HorizontalWebView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/customWebViews/HorizontalWebView.kt
@@ -28,6 +28,10 @@ class HorizontalClickableWebView: WebView {
     var collapsedMethodDoubleClick={}
     var collapsedMethodLongPress={}
     var singleTapMethod={}
+    // Issue #838: optional callback fired with the tap location in CSS
+    // pixels so the page can decide whether the tap actually landed on
+    // the content-classification gate button before clicking it.
+    var singleTapWithCoordsMethod: (Float, Float) -> Unit = { _, _ -> }
     var showLongClickView ={}
     var hideLongClickView ={}
     var dragFunction:(Float) ->Unit={}

--- a/app/src/main/java/com/example/clicker/presentation/stream/customWebViews/HorizontalWebView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/customWebViews/HorizontalWebView.kt
@@ -28,10 +28,6 @@ class HorizontalClickableWebView: WebView {
     var collapsedMethodDoubleClick={}
     var collapsedMethodLongPress={}
     var singleTapMethod={}
-    // Issue #838: optional callback fired with the tap location in CSS
-    // pixels so the page can decide whether the tap actually landed on
-    // the content-classification gate button before clicking it.
-    var singleTapWithCoordsMethod: (Float, Float) -> Unit = { _, _ -> }
     var showLongClickView ={}
     var hideLongClickView ={}
     var dragFunction:(Float) ->Unit={}
@@ -78,6 +74,8 @@ class HorizontalClickableWebView: WebView {
         override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
             Log.d("onSingleTapConfirmed","TAPPING")
             singleTapMethod()
+            val density = context.resources.displayMetrics.density
+            singleTapWithCoordsMethod(e.x / density, e.y / density)
             return super.onSingleTapConfirmed(e)
         }
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/customWebViews/VerticalWebView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/customWebViews/VerticalWebView.kt
@@ -29,10 +29,6 @@ class VerticalWebView: WebView {
     var expandedMethod ={}
     var collapsedMethod={}
     var singleTapMethod={}
-    // Issue #838: optional callback fired with the tap location in CSS
-    // pixels so the page can decide whether the tap actually landed on
-    // the content-classification gate button before clicking it.
-    var singleTapWithCoordsMethod: (Float, Float) -> Unit = { _, _ -> }
 
 
 
@@ -62,6 +58,8 @@ class VerticalWebView: WebView {
         override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
             Log.d("onSingleTapConfirmed","TAPPING")
             singleTapMethod()
+            val density = context.resources.displayMetrics.density
+            singleTapWithCoordsMethod(e.x / density, e.y / density)
             return super.onSingleTapConfirmed(e)
         }
 

--- a/app/src/main/java/com/example/clicker/presentation/stream/customWebViews/VerticalWebView.kt
+++ b/app/src/main/java/com/example/clicker/presentation/stream/customWebViews/VerticalWebView.kt
@@ -29,6 +29,10 @@ class VerticalWebView: WebView {
     var expandedMethod ={}
     var collapsedMethod={}
     var singleTapMethod={}
+    // Issue #838: optional callback fired with the tap location in CSS
+    // pixels so the page can decide whether the tap actually landed on
+    // the content-classification gate button before clicking it.
+    var singleTapWithCoordsMethod: (Float, Float) -> Unit = { _, _ -> }
 
 
 


### PR DESCRIPTION
Closes #838.

Previously every single-tap on the vertical stream WebView fired the JS that clicks the content-classification gate button, even if the user had tapped somewhere else on the page. The issue requested mapping the button's location with `getBoundingClientRect()` and only triggering the click when the tap lands inside that rect.

This PR threads the tap coordinates (in CSS pixels) from `onSingleTapConfirmed` through a new `singleTapWithCoordsMethod` callback on both `HorizontalClickableWebView` and `VerticalWebView`. In `StreamFragment.verticalWebViewOverlayClicked` the unconditional `button.click()` is replaced with a coord-gated version that uses `getBoundingClientRect()` and only clicks when the tap is inside the rect.

```kotlin
override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
    singleTapMethod()
    val density = context.resources.displayMetrics.density
    singleTapWithCoordsMethod(e.x / density, e.y / density)
    return super.onSingleTapConfirmed(e)
}
```

```kotlin
verticalClickableWebView.singleTapWithCoordsMethod = { x, y ->
    val js = """
        (function(){
          var btn = document.querySelector('[data-a-target="content-classification-gate-overlay-start-watching-button"]');
          if (!btn) return false;
          var r = btn.getBoundingClientRect();
          if (${'$'}x >= r.left && ${'$'}x <= r.right && ${'$'}y >= r.top && ${'$'}y <= r.bottom) {
            btn.click();
            return true;
          }
          return false;
        })();
    """
    verticalClickableWebView.evaluateJavascript(js, null)
}
```

The behaviour for the rest of the overlay (toggling visibility, the secondary log call, the horizontal-mode tap method) is unchanged.
